### PR TITLE
Add support for building libxml++ with Meson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ stamp-h?
 /libtool
 
 # MSVC
-/MSVC_Net201?/libxml++/libxml++.rc
+/MSVC_NMake/libxml++/libxml++.rc
 
 # docs
 /docs/doc-install.pl
@@ -70,3 +70,7 @@ stamp-h?
 /tests/*/test.log
 /tests/*/test.trs
 /tests/test-suite.log
+
+# untracked/
+untracked/build_scripts/
+untracked/docs/

--- a/MSVC_NMake/libxml++/meson.build
+++ b/MSVC_NMake/libxml++/meson.build
@@ -1,0 +1,17 @@
+# MSVC_NMake/libxml++
+
+# Input: pkg_conf_data, xmlxxconfig_h
+# Output: xmlxx_rc
+
+xmlxx_rc = configure_file(
+  input: 'libxml++.rc.in',
+  output: '@BASENAME@',
+  configuration: pkg_conf_data,
+)
+
+# Copy the generated configuration header into the MSVC project directory.
+configure_file(
+  input: xmlxxconfig_h,
+  output: 'libxml++config.h',
+  copy: true,
+)

--- a/Makefile.am
+++ b/Makefile.am
@@ -24,5 +24,20 @@ dist_noinst_SCRIPTS = autogen.sh
 
 DISTCLEANFILES = MSVC_NMake/libxml++/libxml++config.h
 
+# Distribute files needed when building libxml++ with Meson.
+EXTRA_DIST = \
+  meson.build \
+  meson_options.txt \
+  libxml++config.h.meson \
+  MSVC_NMake/libxml++/meson.build \
+  docs/manual/meson.build \
+  docs/reference/meson.build \
+  examples/meson.build \
+  libxml++/meson.build \
+  tests/meson.build \
+  tools/build_scripts/tutorial-custom-cmd.py \
+  tools/conf_tests/have_exception_ptr.cc \
+  untracked/README
+
 # Optional: auto-generate the ChangeLog file from the git log on make dist
 include $(top_srcdir)/build/dist-changelog.am

--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,7 @@ LT_PREREQ([2.2.6])
 LT_INIT([dlopen win32-dll disable-static])
 
 AC_SUBST([LIBXMLXX_MODULES], ['libxml-2.0 >= 2.7.7 glibmm-2.4 >= 2.32.0'])
+AC_SUBST([LIBXML2_LIB_NO_PKGCONFIG], [''])
 PKG_CHECK_MODULES([LIBXMLXX], [$LIBXMLXX_MODULES])
 
 AC_LANG([C++])

--- a/docs/manual/meson.build
+++ b/docs/manual/meson.build
@@ -1,0 +1,102 @@
+# docs/manual
+
+# input: install_datadir, xmlxx_pcname, tutorial_custom_cmd_py, python3,
+#        build_documentation, book_name, perl
+# output: can_parse_and_validate, build_pdf_by_default, can_build_pdf,
+#         install_tutorialdir
+
+# xsltproc is required by tutorial_custom_cmd_py html.
+xsltproc = find_program('xsltproc', required: build_documentation)
+xmllint = find_program('xmllint', required: false)
+
+can_parse_and_validate = xmllint.found()
+
+validate = get_option('validation') ? 'true' : 'false'
+
+dblatex = find_program('dblatex', required: false)
+can_build_pdf = dblatex.found() or (xmllint.found() and \
+                find_program('docbook2pdf', required: false).found())
+build_pdf_by_default = get_option('build-pdf')
+
+# Installation directories are relative to {prefix}.
+install_tutorialdir = install_datadir / 'doc' / book_name / 'manual'
+
+if not build_documentation
+  # Documentation shall not be built or installed.
+  # Return to the calling meson.build file.
+  subdir_done()
+endif
+
+doc_dist_dir = 'untracked' / 'docs' / 'manual' # Relative to MESON_DIST_ROOT
+
+# Create a DocBook XML file with the examples' source code included.
+xml_manual_docbook = custom_target('libxml++.xml',
+  input: 'libxml++_without_code.xml',
+  output: 'libxml++.xml',
+  command: [
+    python3, tutorial_custom_cmd_py, 'insert_example_code',
+    meson.current_source_dir() / 'insert_example_code.pl',
+    project_source_root / 'examples',
+    '@INPUT@',
+    '@OUTPUT@',
+  ],
+  build_by_default: true
+)
+
+# Create an html version of the DocBook.
+custom_target('manual_html',
+  input: xml_manual_docbook,
+  output: 'html',
+  command: [
+    python3, tutorial_custom_cmd_py, 'html',
+    meson.current_source_dir() / 'docbook-customisation.xsl', # stylesheet
+    '@INPUT@',
+    '@OUTPUT@',
+  ],
+  build_by_default: true,
+  install: true,
+  install_dir: install_tutorialdir
+)
+
+if can_parse_and_validate
+  # Parse and possibly validate the DocBook.
+  custom_target('manual_xmllint',
+    input: xml_manual_docbook,
+    output: 'manual_xmllint.stamp',
+    command: [
+      python3, tutorial_custom_cmd_py, 'xmllint',
+      validate,
+      '@INPUT@',
+      '@OUTPUT@'
+    ],
+    build_by_default: true,
+  )
+endif
+
+if can_build_pdf
+  # Create a PDF file of the DocBook.
+  # Prefer dblatex, if both dblatex and docbook2pdf are available.
+  custom_target('manual_pdf',
+    input: xml_manual_docbook,
+    output: 'libxml++.pdf',
+    command: [
+      python3, tutorial_custom_cmd_py,
+      dblatex.found() ? 'dblatex' : 'docbook2pdf',
+      '@INPUT@',
+      '@OUTPUT@'
+    ],
+    build_by_default: build_pdf_by_default,
+  )
+endif
+
+if not meson.is_subproject()
+  # Distribute built files.
+  # (add_dist_script() is not allowed in a subproject)
+  meson.add_dist_script(
+    python3.path(), tutorial_custom_cmd_py, 'dist_doc',
+    doc_dist_dir,
+    meson.current_build_dir(),
+    meson.current_build_dir() / 'libxml++.xml',
+    meson.current_build_dir() / 'libxml++.pdf',
+  )
+endif

--- a/docs/reference/meson.build
+++ b/docs/reference/meson.build
@@ -1,0 +1,129 @@
+# docs/reference
+
+# Input: project_build_root, project_source_root, xmlxx_pcname,
+#        xmlxx_api_version, build_documentation, source_h_files,
+#        install_datadir, python3, doc_reference_py
+# Output: install_docdir, install_devhelpdir, book_name
+
+# There are no built source files in libxml++-3.0.
+
+tag_file_modules = [
+  'mm-common-libstdc++',
+  'sigc++-2.0',
+  'glibmm-2.4',
+]
+doxygen_tagfiles = ''
+docinstall_flags = []
+foreach module : tag_file_modules
+  depmod = dependency(module, required: false)
+  if depmod.found()
+    doxytagfile = depmod.get_pkgconfig_variable('doxytagfile')
+    htmlrefpub = depmod.get_pkgconfig_variable('htmlrefpub', default: '')
+    htmlrefdir = depmod.get_pkgconfig_variable('htmlrefdir', default: '')
+    if htmlrefpub == ''
+      htmlrefpub = htmlrefdir
+    elif htmlrefdir == ''
+      htmlrefdir = htmlrefpub
+    endif
+    doxygen_tagfiles += ' "' + doxytagfile + '=' + htmlrefpub + '"'
+
+    # Doxygen <= 1.8.15
+    docinstall_flags += ['-l', doxytagfile.split('/')[-1] + '@' + htmlrefdir]
+    if htmlrefpub != htmlrefdir
+      # Doxygen >= 1.8.16
+      docinstall_flags += ['-l', 's@' + htmlrefpub + '@' + htmlrefdir]
+    endif
+  endif
+endforeach
+
+book_name = xmlxx_pcname
+book_title = meson.project_name() + ' Reference Manual'
+
+# Configuration data for Doxyfile.
+doc_conf_data = configuration_data()
+doc_conf_data.set('configure_input',
+  'docs/reference/Doxyfile. Generated from Doxyfile.in by meson.configure_file().')
+doc_conf_data.set('PACKAGE_NAME', meson.project_name())
+doc_conf_data.set('PACKAGE_VERSION', meson.project_version())
+doc_conf_data.set('abs_top_builddir', project_build_root)
+doc_conf_data.set('abs_top_srcdir', project_source_root)
+doc_conf_data.set('LIBXMLXX_MODULE_NAME', book_name)
+doc_conf_data.set('DOXYGEN_TAGFILES', doxygen_tagfiles)
+
+configure_file(
+  input: 'Doxyfile.in',
+  output: '@BASENAME@',
+  configuration: doc_conf_data,
+)
+
+# Installation directories relative to {prefix}.
+install_docdir = install_datadir / 'doc' / book_name
+install_reference_docdir = install_docdir / 'reference'
+install_devhelpdir = install_datadir / 'devhelp' / 'books' / book_name
+
+if not build_documentation
+  # Documentation shall not be built or installed.
+  # Return to the calling meson.build file.
+  subdir_done()
+endif
+
+# Input .h files to Doxygen.
+src_h_files = []
+foreach file : source_h_files
+  src_h_files += project_source_root / 'libxml++' / file
+endforeach
+src_h_files += project_source_root / 'libxml++' / 'libxml++.h'
+
+doctool_dir = project_source_root / 'untracked' / 'docs' # MMDOCTOOLDIR
+doctool_dist_dir = 'untracked' / 'docs' # Relative to MESON_DIST_ROOT
+
+tag_file = custom_target('html_and_tag',
+  input: src_h_files,
+  output: book_name + '.tag',
+  command: [
+    python3, doc_reference_py, 'doxygen',
+    doctool_dir,
+    '@OUTPUT@',
+    '@INPUT@',
+  ],
+  build_by_default: build_documentation,
+  install: true,
+  install_dir: install_reference_docdir,
+)
+
+devhelp_file = custom_target('devhelp',
+  input: tag_file,
+  output: book_name + '.devhelp2',
+  command: [
+    python3, doc_reference_py, 'devhelp',
+    doctool_dir,
+    '@INPUT@',
+    '@OUTPUT@',
+    book_name,
+    book_title,
+  ],
+  build_by_default: build_documentation,
+)
+
+# Install Devhelp file and html files.
+meson.add_install_script(
+  python3.path(), doc_reference_py, 'install_doc',
+  doctool_dir,
+  devhelp_file.full_path(),
+  install_devhelpdir,
+  install_reference_docdir / 'html',
+  docinstall_flags
+)
+
+if not meson.is_subproject()
+  # Distribute built files and files copied by mm-common-get.
+  # (add_dist_script() is not allowed in a subproject)
+  meson.add_dist_script(
+    python3.path(), doc_reference_py, 'dist_doc',
+    doctool_dir,
+    doctool_dist_dir,
+    meson.current_build_dir(),
+    tag_file.full_path(),
+    devhelp_file.full_path(),
+  )
+endif

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,0 +1,61 @@
+# examples
+
+# Input: xmlxx_dep, build_examples
+# Output: -
+
+example_programs = [
+# [[dir-name], exe-name, [sources], [arguments]]
+  [['dom_build'], 'example', ['main.cc'], []],
+  [['dom_parse_entities'], 'example', ['main.cc', '..' / 'testutilities.cc'], []],
+  [['dom_parser'], 'example', ['main.cc', '..' / 'testutilities.cc'], []],
+  [['dom_parser_raw'], 'example', ['main.cc'], []],
+  [['dom_read_write'], 'example', ['main.cc'],
+    ['example.xml', meson.current_build_dir() / 'dom_read_write_example_output.xml']],
+  [['dom_update_namespace'], 'example', ['main.cc'], []],
+  [['dom_xinclude'], 'example', ['main.cc'], []],
+  [['dom_xpath'], 'example', ['main.cc'], []],
+  [['dtdvalidation'], 'example', ['main.cc'], []],
+  [['import_node'], 'example', ['main.cc'], []],
+  [['sax_exception'], 'example', ['main.cc', 'myparser.cc'], []],
+  [['sax_parser'], 'example', ['main.cc', 'myparser.cc'], []],
+  [['sax_parser_build_dom'], 'example', ['main.cc', 'svgparser.cc',
+    'svgdocument.cc', 'svgelement.cc'], []],
+  [['sax_parser_entities'], 'example', ['main.cc', 'myparser.cc'], []],
+  [['schemavalidation'], 'example', ['main.cc'], []],
+  [['textreader'], 'example', ['main.cc'], []],
+]
+
+foreach ex : example_programs
+  dir = ''
+  foreach dir_part : ex[0]
+    dir = dir / dir_part
+  endforeach
+  ex_name = (dir / ex[1]).underscorify()
+  ex_sources = []
+  foreach src : ex[2]
+    ex_sources += dir / src
+  endforeach
+
+  exe_file = executable(ex_name, ex_sources,
+    dependencies: xmlxx_dep,
+    gui_app: false,
+    build_by_default: build_examples
+  )
+
+  if build_examples
+    # Some programs can find their input file(s) only if the current directory,
+    # when they are executed, is the program's own source directory.
+    # To make these program invocations as consistent as possible, and to avoid
+    # having to specify parameters for the programs, the programs are executed
+    # from their own source directory.
+    #
+    # dom_read_write shall write its output file in the build directory.
+    # It's necessary to specify parameters when the input file and the output
+    # file are located in different directories.
+
+    test(ex_name, exe_file,
+      workdir: meson.current_source_dir() / dir,
+      args: ex[3],
+    )
+  endif
+endforeach

--- a/libxml++.pc.in
+++ b/libxml++.pc.in
@@ -15,5 +15,5 @@ Description: C++ wrapper for libxml
 Version: @PACKAGE_VERSION@
 URL: http://libxmlplusplus.sourceforge.net/
 Requires: @LIBXMLXX_MODULES@
-Libs: -L${libdir} -lxml++-@LIBXMLXX_API_VERSION@
+Libs: -L${libdir} -lxml++-@LIBXMLXX_API_VERSION@ @LIBXML2_LIB_NO_PKGCONFIG@
 Cflags: -I${includedir}/@LIBXMLXX_MODULE_NAME@ -I${libdir}/@LIBXMLXX_MODULE_NAME@/include

--- a/libxml++/meson.build
+++ b/libxml++/meson.build
@@ -1,0 +1,120 @@
+# libxml++
+
+# Input: xmlxx_build_dep, xmlxx_pcname, xmlxx_libversion, xmlxx_api_version,
+#        install_includedir, xmlxx_rc
+# Output: source_h_files, xmlxx_dep
+
+# There are no built source files in libxml++-3.0.
+
+source_h_files = []
+source_cc_files = []
+
+xmlxx_base_h_cc_files = [
+  'attribute',
+  'attributedeclaration',
+  'attributenode',
+  'document',
+  'dtd',
+  'keepblanks',
+  'noncopyable',
+  'relaxngschema',
+  'schemabase',
+  'xsdschema',
+]
+
+xmlxx_subdir_h_cc_files = [
+# [ dir-name, [files]]
+  ['exceptions', [
+    'exception',
+    'parse_error',
+    'validity_error',
+    'internal_error',
+    'wrapped_exception',
+  ]],
+  ['io', [
+    'istreamparserinputbuffer',
+    'outputbuffer',
+    'ostreamoutputbuffer',
+    'parserinputbuffer',
+  ]],
+  ['nodes', [
+    'cdatanode',
+    'commentnode',
+    'contentnode',
+    'element',
+    'entitydeclaration',
+    'entityreference',
+    'node',
+    'processinginstructionnode',
+    'textnode',
+    'xincludeend',
+    'xincludestart',
+  ]],
+  ['parsers', [
+    'parser',
+    'saxparser',
+    'domparser',
+    'textreader',
+  ]],
+  ['validators', [
+    'dtdvalidator',
+    'relaxngvalidator',
+    'schemavalidatorbase',
+    'validator',
+    'xsdvalidator',
+  ]],
+]
+
+foreach f : xmlxx_base_h_cc_files
+  source_h_files += f + '.h'
+  source_cc_files += f + '.cc'
+endforeach
+
+install_headers('libxml++.h', subdir: xmlxx_pcname / 'libxml++')
+install_headers(source_h_files, subdir: xmlxx_pcname / 'libxml++')
+
+foreach dir_files : xmlxx_subdir_h_cc_files
+  dir = dir_files[0]
+  subdir_h_files = []
+  foreach f : dir_files[1]
+    subdir_h_files += dir / f + '.h'
+    source_cc_files += dir / f + '.cc'
+  endforeach
+  source_h_files += subdir_h_files
+  install_headers(subdir_h_files, subdir: xmlxx_pcname / 'libxml++' / dir)
+endforeach
+
+xmlxx_cpp_args = [ '-LIBXMLPP_BUILD=1' ]
+
+# Make sure we are exporting the symbols from the DLL
+if is_msvc
+  xmlxx_cpp_args += ['-D_WINDLL']
+endif
+
+extra_xmlxx_objects = []
+
+# Build the .rc file for Windows builds and link to it
+if host_machine.system() == 'windows'
+  windows = import('windows')
+  xmlxx_res = windows.compile_resources(xmlxx_rc)
+  extra_xmlxx_objects += xmlxx_res
+endif
+
+extra_include_dirs = ['..']
+xmlxx_library = library('xml++-' + xmlxx_api_version,
+  source_cc_files,
+  extra_xmlxx_objects,
+  version: xmlxx_libversion,
+  include_directories: extra_include_dirs,
+  cpp_args: xmlxx_cpp_args,
+  dependencies: xmlxx_build_dep,
+  install: true,
+)
+
+# This is useful in the main project when libxml++ is used as a subproject.
+# It's also used when building example programs and test programs.
+xmlxx_dep = declare_dependency(
+  link_with: xmlxx_library,
+  include_directories: extra_include_dirs,
+  dependencies: xmlxx_build_dep
+)

--- a/libxml++/meson.build
+++ b/libxml++/meson.build
@@ -84,7 +84,7 @@ foreach dir_files : xmlxx_subdir_h_cc_files
   install_headers(subdir_h_files, subdir: xmlxx_pcname / 'libxml++' / dir)
 endforeach
 
-xmlxx_cpp_args = [ '-LIBXMLPP_BUILD=1' ]
+xmlxx_cpp_args = [ '-DLIBXMLPP_BUILD=1' ]
 
 # Make sure we are exporting the symbols from the DLL
 if is_msvc

--- a/libxml++config.h.meson
+++ b/libxml++config.h.meson
@@ -1,0 +1,32 @@
+#ifndef _LIBXMLPP_CONFIG_H
+#define _LIBXMLPP_CONFIG_H
+
+#include <glibmmconfig.h>
+
+/* Define to omit deprecated API from the library. */
+#mesondefine LIBXMLXX_DISABLE_DEPRECATED
+
+/* Defined if the C++ library supports std::exception_ptr. */
+#mesondefine LIBXMLXX_HAVE_EXCEPTION_PTR
+
+/* Major version number of libxml++. */
+#mesondefine LIBXMLXX_MAJOR_VERSION
+
+/* Minor version number of libxml++. */
+#mesondefine LIBXMLXX_MINOR_VERSION
+
+/* Micro version number of libxml++. */
+#mesondefine LIBXMLXX_MICRO_VERSION
+
+#if defined (GLIBMM_DLL) && !defined (LIBXMLXX_STATIC)
+  #ifdef LIBXMLPP_BUILD
+    #define LIBXMLPP_API __declspec(dllexport)
+  #else
+    #define LIBXMLPP_API __declspec(dllimport)
+  #endif /* LIBXMLPP_BUILD - DLL */
+#else
+  /* Build a static library or a non-Windows library*/
+  #define LIBXMLPP_API
+#endif /* GLIBMM_DLL */
+
+#endif /* _LIBXMLPP_CONFIG_H */

--- a/meson.build
+++ b/meson.build
@@ -94,90 +94,66 @@ install_pkgconfigdir = install_libdir / 'pkgconfig'
 # for its pkg-config files on Visual Studio as well
 glibmm_req = '>= 2.32.0'
 
-# libxml-2.0 supported pkg-config files on MSVC files for a good while, so just use that
-xml2_req = '>= 2.7.7'
-xml2_dep = dependency('libxml-2.0', version: xml2_req)
+# libxml2's Windows-specific Makefiles don't create pkg-config files for us, so
+# we may need to look for it manually on Windows
+xml2_min_ver = '2.7.7'
+xml2_req = '>= @0@'.format(xml2_min_ver)
+xml2_dep = dependency('libxml-2.0', version: xml2_req, required: host_machine.system() != 'windows')
+
+if not xml2_dep.found()
+  libxml2_lib = 'libxml2'
+  xml2_dep =  cpp_compiler.find_library(libxml2_lib,
+                                        has_headers: [
+                                          'libxml/globals.h',
+                                          'libxml/parser.h',
+                                          'libxml/parserInternals.h',
+                                          'libxml/relaxng.h',
+                                          'libxml/tree.h',
+                                          'libxml/xinclude.h',
+                                          'libxml/xpath.h',
+                                          'libxml/xpathInternals.h',
+                                          'libxml/xmlerror.h',
+                                          'libxml/xmlIO.h',
+                                          'libxml/xmlreader.h',
+                                          'libxml/xmlschemas.h',
+                                        ])
+
+    xml_min_ver_split = xml2_min_ver.split('.')
+    xml_min_ver_int = xml_min_ver_split[0].to_int() * 10000 + \
+                      xml_min_ver_split[1].to_int() * 100 + \
+                      xml_min_ver_split[2].to_int()
+
+    if not cpp_compiler.compiles('''#include <libxml/tree.h>
+                                    #if LIBXML_VERSION < @0@
+                                    # error libxml2 versions must be @1@ or later
+                                    #endif'''.format(xml_min_ver_int.to_string(), xml2_min_ver),
+                                    name : 'libxml2 is @0@ or later'.format(xml2_min_ver))
+      error('Your libxml2 installation must be @0@ or later'.format(xml2_min_ver))
+    endif
+endif
 
 # The -mm libraries do not yet have pkg-config files for MSVC builds,
 # so check for them manually
 glibmm_req_minor_ver = '4'
 
-glibmm_dep = dependency('glibmm-2.@0@'.format(glibmm_req_minor_ver), version: glibmm_req, required: not is_msvc)
+glibmm_dep = dependency('glibmm-2.@0@'.format(glibmm_req_minor_ver), version: glibmm_req)
 
-if is_msvc
-  # We must have Visual Studio 2013 or later...
-  assert(cpp_compiler.version().split('.')[0].to_int() >= 18, 'Visual Studio 2013 or later is required')
+xmlxx_requires = ''
+libxml2_lib_pkgconfig = ''
 
-  sigc_major_ver = '2'
-
-  if not glibmm_dep.found()
-    assert(cpp_compiler.has_header('sigc++-@0@.0/sigc++/sigc++.h'.format(sigc_major_ver)) and cpp_compiler.has_header('sigc++-@0@.0/include/sigc++config.h'.format(sigc_major_ver)),
-           'sigc++-@0@.x headers are required'.format(sigc_major_ver))
-    assert(cpp_compiler.has_header('glibmm-2.@0@/glibmm.h'.format(glibmm_req_minor_ver)) and cpp_compiler.has_header('glibmm-2.@0@/include/glibmmconfig.h'.format(glibmm_req_minor_ver)),
-           'glibmm-2.@0@ headers are required'.format(glibmm_req_minor_ver))
-
-  else
-    sigc_dep = dependency('', required: false) # glibmm covers for libsigc++ in its pkg-config file
-  endif
-  message('Ensure your INCLUDE and LIB contain the paths that lead to the appropriate headers and .lib\'s for glibmm-2.@0@ and libsigc++-2.x'.format(glibmm_req_minor_ver))
-
-  # We need to look for appropriate versions of Visual
-  # Studio since those built by NMake and the former
-  # Visual Studio projects are versioned by the VS versions
-  if cpp_compiler.version().split('.')[0].to_int() == 18
-    msvc_check_range = [12] # Visual Studio 2013
-    warning('Visual Studio 2013 must configure without -Dwarnings=fatal, which is the default')
-  elif cpp_compiler.version().split('.')[0].to_int() == 19
-    # Visual Studio 2019 can consume libraries built with 2017 and 2015
-    # and Visual Studio 2017 can consume libraries built with 2015
-    msvc_check_range = [14] # Visual Studio 2015, 2017, 2019
-    message('It is safe to ignore warnings from Meson that MSVC does not support C++11')
-  endif
-
-  debugsuffix = ''
-  if get_option('buildtype') == 'debug'
-    debugsuffix = '-d'
-  endif
-
-  # We can be looking for MSVC 2015-built libraries on 2017 and 2019 builds as well,
-  # as well as 2017-built libraries on 2019 as well, so we can't just assume that
-  # libraries exist, but check that compatible versions are really found
-  foreach v : msvc_check_range
-    glibmm_dep = glibmm_dep.found() ? glibmm_dep : cpp_compiler.find_library('glibmm-vc@0@0@1@-2_@2@'.format(v.to_string(), debugsuffix, glibmm_req_minor_ver), required: false)
-  endforeach
-
-  if glibmm_dep.type_name() == 'library'
-    warning('Note: Be sure to check that this finds the same libsigc++ .lib your glibmm is linked to')
-    sigc_dep = cpp_compiler.find_library('sigc-@0@.0'.format(sigc_major_ver), required: false)
-    foreach v : msvc_check_range
-      sigc_dep = sigc_dep.found() ? sigc_dep : cpp_compiler.find_library('sigc-vc@0@0@1@-2_0'.format(v.to_string(), debugsuffix), required: false)
-    endforeach
-  endif
-
-  # Now make sure the appropriate -mm libraries are found
-  assert(glibmm_dep.found() and (glibmm_dep.type_name() == 'pkgconfig' or sigc_dep.found()), 'Appropriate glibmm-vcxx0@0@-2_@1@.lib and sigc-vcxx0@0@-@2@_0.lib are required'.format(debugsuffix, glibmm_req_minor_ver, sigc_major_ver))
-
-  # Put glibmm in the required packages if we find it by pkg-config
-  mm_lib_requires = ''
-  if glibmm_dep.type_name() == 'pkgconfig'
-    mm_lib_requires += ' '.join([
-      'glibmm-2.@0@'.format(glibmm_req_minor_ver), glibmm_req,
-    ]) + ' '
-  endif
-
-  xmlxx_requires = mm_lib_requires + ' '.join([
-    'libxml-2.0', xml2_req,
-  ])
-
-  xmlxx_build_dep = [glibmm_dep, sigc_dep, xml2_dep]
+# Put libxml-2.0 in the 'Requires:' section in the generated pkg-config file if
+# we found it by pkg-config
+if xml2_dep.type_name() == 'pkgconfig'
+  xmlxx_requires += ' '.join(['libxml-2.0', xml2_req]) + ' '
 else
-  # not MSVC
-  xmlxx_build_dep = [xml2_dep, glibmm_dep]
-  xmlxx_requires = ' '.join([
-    'libxml-2.0', xml2_req,
-    'glibmm-2.@0@'.format(glibmm_req_minor_ver), glibmm_req,
-  ])
+  libxml2_lib_pkgconfig = '-l@0@'.format(libxml2_lib)
 endif
+
+# ...Then put glibmm-2.x in the 'Requires:' section in the generated pkg-config file
+xmlxx_requires += ' '.join(['glibmm-2.@0@'.format(glibmm_req_minor_ver), glibmm_req])
+
+# Make sure we link to libxml-2.0 and glibmm
+xmlxx_build_dep = [xml2_dep, glibmm_dep]
 
 # Some dependencies are required only in maintainer mode and/or if
 # reference documentation shall be built.
@@ -275,6 +251,7 @@ pkg_conf_data.set('PACKAGE_VERSION', meson.project_version())
 pkg_conf_data.set('LIBXMLXX_MODULE_NAME', xmlxx_pcname)
 pkg_conf_data.set('LIBXMLXX_API_VERSION', xmlxx_api_version)
 pkg_conf_data.set('LIBXMLXX_MODULES', xmlxx_requires)
+pkg_conf_data.set('LIBXML2_LIB_NO_PKGCONFIG', libxml2_lib_pkgconfig)
 
 if not build_deprecated_api
   pkg_conf_data.set('LIBXMLXX_DISABLE_DEPRECATED', 1)

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,388 @@
+# This file is part of libxml++.
+
+project('libxml++', 'cpp',
+  version: '3.2.0',
+  license: 'LGPLv2.1+',
+  default_options: [
+    'cpp_std=c++11'
+  ],
+  meson_version: '>= 0.50.0', # required for python3.path()
+)
+
+xmlxx_api_version = '3.0'
+xmlxx_pcname = meson.project_name() + '-' + xmlxx_api_version
+
+xmlxx_version_array = meson.project_version().split('.')
+xmlxx_major_version = xmlxx_version_array[0].to_int()
+xmlxx_minor_version = xmlxx_version_array[1].to_int()
+xmlxx_micro_version = xmlxx_version_array[2].to_int()
+
+# http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
+# The relation between libtool's current:revison:age interface versioning
+# and the .so filename, .so.x.y.z, is
+# x = current - age
+# y = age
+# z = revision
+# If libtool_soversion is updated as described in libtool's documentation,
+# x.y.z will usually *not* be equal to meson.project_version().
+libtool_soversion = [1, 0, 0]
+xmlxx_libversion = '@0@.@1@.@2@'.format(
+  libtool_soversion[0] - libtool_soversion[2],
+  libtool_soversion[2],
+  libtool_soversion[1])
+
+# Use these instead of meson.source_root() and meson.build_root() in subdirectories.
+# source_root() and build_root() are not useful, if this is a subproject.
+project_source_root = meson.current_source_dir()
+project_build_root = meson.current_build_dir()
+
+cpp_compiler = meson.get_compiler('cpp')
+is_msvc = cpp_compiler.get_id() == 'msvc'
+python3 = import('python').find_installation('python3')
+
+python_version = python3.language_version()
+python_version_req = '>= 3.5'
+if not python_version.version_compare(python_version_req)
+  error('Requires Python @0@, found @1@.'.format(python_version_req, python_version))
+endif
+
+# Do we build from a git repository?
+# Suppose we do if and only if a '.git' directory or file exists.
+cmd_py = '''
+import os
+import sys
+sys.exit(os.path.isdir("@0@") or os.path.isfile("@0@"))
+'''.format(project_source_root / '.git')
+is_git_build = run_command(python3, '-c', cmd_py).returncode() != 0
+
+# Are we testing a dist tarball while it's being built?
+# There ought to be a better way. https://github.com/mesonbuild/meson/issues/6866
+is_dist_check = project_source_root.contains('dist-unpack') and \
+                project_build_root.contains('dist-build')
+
+# Options.
+maintainer_mode_opt = get_option('maintainer-mode')
+maintainer_mode = maintainer_mode_opt == 'true' or \
+                 (maintainer_mode_opt == 'if-git-build' and is_git_build)
+if is_dist_check
+  message('Looks like a tarball is being tested. ' + \
+    'Option "dist-warnings" is used instead of "warnings".')
+  warning_level = get_option('dist-warnings')
+else
+  warning_level = get_option('warnings')
+endif
+build_deprecated_api = get_option('build-deprecated-api')
+build_documentation_opt = get_option('build-documentation')
+build_documentation = build_documentation_opt == 'true' or \
+                     (build_documentation_opt == 'if-maintainer-mode' and maintainer_mode)
+build_examples = get_option('build-examples')
+build_tests = get_option('build-tests')
+
+# Installation directories are relative to {prefix}.
+install_prefix = get_option('prefix')
+install_includedir = get_option('includedir')
+install_libdir = get_option('libdir')
+install_datadir = get_option('datadir')
+install_pkgconfigdir = install_libdir / 'pkgconfig'
+
+# Dependencies.
+# xmlxx_build_dep: Dependencies when building the libxml++ library.
+# xmlxx_dep (created in atk/atkmm/meson.build):
+#   Dependencies when using the atkmm library.
+
+# glibmm recently gained Meson build support, so we can try looking
+# for its pkg-config files on Visual Studio as well
+glibmm_req = '>= 2.32.0'
+
+# libxml-2.0 supported pkg-config files on MSVC files for a good while, so just use that
+xml2_req = '>= 2.7.7'
+xml2_dep = dependency('libxml-2.0', version: xml2_req)
+
+# The -mm libraries do not yet have pkg-config files for MSVC builds,
+# so check for them manually
+glibmm_req_minor_ver = '4'
+
+glibmm_dep = dependency('glibmm-2.@0@'.format(glibmm_req_minor_ver), version: glibmm_req, required: not is_msvc)
+
+if is_msvc
+  # We must have Visual Studio 2013 or later...
+  assert(cpp_compiler.version().split('.')[0].to_int() >= 18, 'Visual Studio 2013 or later is required')
+
+  sigc_major_ver = '2'
+
+  if not glibmm_dep.found()
+    assert(cpp_compiler.has_header('sigc++-@0@.0/sigc++/sigc++.h'.format(sigc_major_ver)) and cpp_compiler.has_header('sigc++-@0@.0/include/sigc++config.h'.format(sigc_major_ver)),
+           'sigc++-@0@.x headers are required'.format(sigc_major_ver))
+    assert(cpp_compiler.has_header('glibmm-2.@0@/glibmm.h'.format(glibmm_req_minor_ver)) and cpp_compiler.has_header('glibmm-2.@0@/include/glibmmconfig.h'.format(glibmm_req_minor_ver)),
+           'glibmm-2.@0@ headers are required'.format(glibmm_req_minor_ver))
+
+  else
+    sigc_dep = dependency('', required: false) # glibmm covers for libsigc++ in its pkg-config file
+  endif
+  message('Ensure your INCLUDE and LIB contain the paths that lead to the appropriate headers and .lib\'s for glibmm-2.@0@ and libsigc++-2.x'.format(glibmm_req_minor_ver))
+
+  # We need to look for appropriate versions of Visual
+  # Studio since those built by NMake and the former
+  # Visual Studio projects are versioned by the VS versions
+  if cpp_compiler.version().split('.')[0].to_int() == 18
+    msvc_check_range = [12] # Visual Studio 2013
+    warning('Visual Studio 2013 must configure without -Dwarnings=fatal, which is the default')
+  elif cpp_compiler.version().split('.')[0].to_int() == 19
+    # Visual Studio 2019 can consume libraries built with 2017 and 2015
+    # and Visual Studio 2017 can consume libraries built with 2015
+    msvc_check_range = [14] # Visual Studio 2015, 2017, 2019
+    message('It is safe to ignore warnings from Meson that MSVC does not support C++11')
+  endif
+
+  debugsuffix = ''
+  if get_option('buildtype') == 'debug'
+    debugsuffix = '-d'
+  endif
+
+  # We can be looking for MSVC 2015-built libraries on 2017 and 2019 builds as well,
+  # as well as 2017-built libraries on 2019 as well, so we can't just assume that
+  # libraries exist, but check that compatible versions are really found
+  foreach v : msvc_check_range
+    glibmm_dep = glibmm_dep.found() ? glibmm_dep : cpp_compiler.find_library('glibmm-vc@0@0@1@-2_@2@'.format(v.to_string(), debugsuffix, glibmm_req_minor_ver), required: false)
+  endforeach
+
+  if glibmm_dep.type_name() == 'library'
+    warning('Note: Be sure to check that this finds the same libsigc++ .lib your glibmm is linked to')
+    sigc_dep = cpp_compiler.find_library('sigc-@0@.0'.format(sigc_major_ver), required: false)
+    foreach v : msvc_check_range
+      sigc_dep = sigc_dep.found() ? sigc_dep : cpp_compiler.find_library('sigc-vc@0@0@1@-2_0'.format(v.to_string(), debugsuffix), required: false)
+    endforeach
+  endif
+
+  # Now make sure the appropriate -mm libraries are found
+  assert(glibmm_dep.found() and (glibmm_dep.type_name() == 'pkgconfig' or sigc_dep.found()), 'Appropriate glibmm-vcxx0@0@-2_@1@.lib and sigc-vcxx0@0@-@2@_0.lib are required'.format(debugsuffix, glibmm_req_minor_ver, sigc_major_ver))
+
+  # Put glibmm in the required packages if we find it by pkg-config
+  mm_lib_requires = ''
+  if glibmm_dep.type_name() == 'pkgconfig'
+    mm_lib_requires += ' '.join([
+      'glibmm-2.@0@'.format(glibmm_req_minor_ver), glibmm_req,
+    ]) + ' '
+  endif
+
+  xmlxx_requires = mm_lib_requires + ' '.join([
+    'libxml-2.0', xml2_req,
+  ])
+
+  xmlxx_build_dep = [glibmm_dep, sigc_dep, xml2_dep]
+else
+  # not MSVC
+  xmlxx_build_dep = [xml2_dep, glibmm_dep]
+  xmlxx_requires = ' '.join([
+    'libxml-2.0', xml2_req,
+    'glibmm-2.@0@'.format(glibmm_req_minor_ver), glibmm_req,
+  ])
+endif
+
+# Some dependencies are required only in maintainer mode and/or if
+# reference documentation shall be built.
+mm_common_get = find_program('mm-common-get', required: false)
+if maintainer_mode and not mm_common_get.found()
+  error('Maintainer mode requires the \'mm-common-get\' command.\n' +
+    'Use \'-Dmaintainer-mode=false\' or install the \'mm-common\' package, version 1.0.0 or higher')
+endif
+perl = find_program('perl', required: build_documentation)
+doxygen = find_program('doxygen', required: build_documentation)
+dot = find_program('dot', required: build_documentation) # Used by Doxygen
+xsltproc = find_program('xsltproc', required: build_documentation)
+
+# Script files copied to 'untracked/' by mm-common-get.
+script_dir = project_source_root / 'untracked' / 'build_scripts'
+doc_reference_py = script_dir / 'doc-reference.py'
+dist_changelog_py = script_dir / 'dist-changelog.py'
+dist_build_scripts_py = script_dir / 'dist-build-scripts.py'
+
+if maintainer_mode
+  # Copy files to untracked/build_scripts and untracked/docs.
+  run_command(mm_common_get, '--force', script_dir,
+    project_source_root / 'untracked' / 'docs')
+else
+  cmd_py = '''
+import os
+import sys
+sys.exit(os.path.isfile("@0@"))
+'''.format(doc_reference_py)
+  file_exists = run_command(python3, '-c', cmd_py).returncode() != 0
+  if not file_exists
+    warning('Missing files in untracked/. ' + \
+      'Enable maintainer-mode if you want to build documentation or create a dist tarball.')
+  endif
+endif
+
+# xmlxx's own script files.
+xmlxx_script_dir = project_source_root / 'tools' / 'build_scripts'
+tutorial_custom_cmd_py = xmlxx_script_dir / 'tutorial-custom-cmd.py'
+
+if is_msvc
+  add_project_arguments(cpp_compiler.get_supported_arguments([ '/utf-8', '/wd4828']), language: 'cpp')
+endif
+
+# Set compiler warnings.
+warning_flags = []
+if warning_level == 'min'
+  if is_msvc
+    warning_flags = ['/W3']
+  else
+    warning_flags = ['-Wall']
+  endif
+elif warning_level == 'max' or warning_level == 'fatal'
+  if is_msvc
+    warning_flags = ['/W4']
+  else
+    warning_flags = '-pedantic -Wall -Wextra -Wformat-security -Wsuggest-override -Wshadow -Wno-long-long'.split()
+  endif
+  if warning_level == 'fatal'
+    if is_msvc
+      warning_flags += ['/WX']
+    else
+      warning_flags += ['-Werror']
+    endif
+    deprecations = 'G GLIBMM SIGCXX'.split()
+    foreach d : deprecations
+      warning_flags += '-D@0@_DISABLE_DEPRECATED'.format(d)
+    endforeach
+  endif
+endif
+
+warning_flags = cpp_compiler.get_supported_arguments(warning_flags)
+add_project_arguments(warning_flags, language: 'cpp')
+
+# MSVC: Ignore warnings that aren't really harmful, but make those
+#       that should not be overlooked stand out.
+if is_msvc
+  foreach wd : ['/FImsvc_recommended_pragmas.h', '/wd4267', '/wd4530', '/wd4251']
+    disabled_warning = cpp_compiler.get_supported_arguments(wd)
+    add_project_arguments(disabled_warning, language: 'cpp')
+  endforeach
+endif
+
+# Configure files
+pkg_conf_data = configuration_data()
+pkg_conf_data.set('prefix', install_prefix)
+pkg_conf_data.set('exec_prefix', '${prefix}')
+pkg_conf_data.set('libdir', '${exec_prefix}' / install_libdir)
+pkg_conf_data.set('datarootdir', '${prefix}' / install_datadir)
+pkg_conf_data.set('datadir', '${datarootdir}')
+pkg_conf_data.set('includedir', '${prefix}' / install_includedir)
+pkg_conf_data.set('PACKAGE_NAME', meson.project_name()) # MSVC_NMake/libxml++/libxml++.rc
+pkg_conf_data.set('PACKAGE_TARNAME', meson.project_name())
+pkg_conf_data.set('PACKAGE_VERSION', meson.project_version())
+pkg_conf_data.set('LIBXMLXX_MODULE_NAME', xmlxx_pcname)
+pkg_conf_data.set('LIBXMLXX_API_VERSION', xmlxx_api_version)
+pkg_conf_data.set('LIBXMLXX_MODULES', xmlxx_requires)
+
+if not build_deprecated_api
+  pkg_conf_data.set('LIBXMLXX_DISABLE_DEPRECATED', 1)
+endif
+pkg_conf_data.set('LIBXMLXX_MAJOR_VERSION', xmlxx_major_version)
+pkg_conf_data.set('LIBXMLXX_MINOR_VERSION', xmlxx_minor_version)
+pkg_conf_data.set('LIBXMLXX_MICRO_VERSION', xmlxx_micro_version)
+
+# Configuration test
+if cpp_compiler.compiles(files('tools' / 'conf_tests' / 'have_exception_ptr.cc'))
+  pkg_conf_data.set('LIBXMLXX_HAVE_EXCEPTION_PTR', 1)
+endif
+
+# Static library?
+library_build_type = get_option('default_library')
+
+if cpp_compiler.get_argument_syntax() == 'msvc'
+  if library_build_type == 'static' or library_build_type == 'both'
+    error('Static builds are not supported by MSVC-style builds')
+  endif
+endif
+
+configure_file(
+  input: 'libxml++.pc.in',
+  output: xmlxx_pcname + '.pc',
+  configuration: pkg_conf_data,
+  install_dir: install_pkgconfigdir,
+)
+
+install_includeconfigdir = install_libdir / xmlxx_pcname / 'include'
+xmlxxconfig_h = configure_file(
+  input: 'libxml++config.h.meson',
+  output: 'libxml++config.h',
+  configuration: pkg_conf_data,
+  install_dir: install_includeconfigdir,
+)
+
+subdir('MSVC_NMake/libxml++')
+subdir('libxml++')
+subdir('examples')
+subdir('tests')
+subdir('docs/reference')
+subdir('docs/manual')
+
+if not meson.is_subproject()
+  # Add a ChangeLog file to the distribution directory.
+  # (add_dist_script() is not allowed in a subproject)
+  meson.add_dist_script(
+    python3.path(), dist_changelog_py,
+    project_source_root,
+  )
+  # Add build scripts to the distribution directory, and delete .gitignore
+  # files and an empty $MESON_DIST_ROOT/build/ directory.
+  meson.add_dist_script(
+    python3.path(), dist_build_scripts_py,
+    project_source_root,
+    'untracked' / 'build_scripts',
+  )
+endif
+
+# Print a summary.
+real_maintainer_mode = ''
+if maintainer_mode_opt == 'if-git-build'
+  real_maintainer_mode = ' (@0@)'.format(maintainer_mode)
+endif
+
+real_build_documentation = ''
+if build_documentation_opt == 'if-maintainer-mode'
+  real_build_documentation = ' (@0@)'.format(build_documentation)
+endif
+
+validate = get_option('validation') and can_parse_and_validate
+explain_val = ''
+if get_option('validation') and not validate
+  explain_val = ' (requires xmllint)'
+endif
+
+build_pdf = build_pdf_by_default and can_build_pdf
+explain_pdf = ''
+if build_pdf_by_default and not build_pdf
+  explain_pdf = ' (requires dblatex or (xmllint and docbook2pdf))'
+endif
+
+summary = [
+  '',
+  '------',
+  meson.project_name() + ' ' + meson.project_version(),
+  '',
+  '         Maintainer mode: @0@@1@'.format(maintainer_mode_opt, real_maintainer_mode),
+  '       Compiler warnings: @0@'.format(warning_level),
+  '    Build deprecated API: @0@'.format(build_deprecated_api),
+  'Build HTML documentation: @0@@1@'.format(build_documentation_opt, real_build_documentation),
+  '          XML validation: @0@@1@'.format(validate, explain_val),
+  '               Build PDF: @0@@1@'.format(build_pdf, explain_pdf),
+#  '  Build example programs: @0@'.format(build_examples),
+  '     Build test programs: @0@'.format(build_tests),
+  'Directories:',
+  '                  prefix: @0@'.format(install_prefix),
+  '              includedir: @0@'.format(install_prefix / install_includedir),
+  '         includeatkmmdir: @0@'.format(install_prefix / install_includedir / xmlxx_pcname),
+  '                  libdir: @0@'.format(install_prefix / install_libdir),
+  '        includeconfigdir: @0@'.format(install_prefix / install_includeconfigdir),
+  '            pkgconfigdir: @0@'.format(install_prefix / install_pkgconfigdir),
+  '                 datadir: @0@'.format(install_prefix / install_datadir),
+  '                  docdir: @0@'.format(install_prefix / install_docdir),
+  '              devhelpdir: @0@'.format(install_prefix / install_devhelpdir),
+  '             tutorialdir: @0@'.format(install_prefix / install_tutorialdir),
+  '------',
+]
+
+message('\n'.join(summary))

--- a/meson.build
+++ b/meson.build
@@ -231,7 +231,7 @@ add_project_arguments(warning_flags, language: 'cpp')
 # MSVC: Ignore warnings that aren't really harmful, but make those
 #       that should not be overlooked stand out.
 if is_msvc
-  foreach wd : ['/FImsvc_recommended_pragmas.h', '/wd4267', '/wd4530', '/wd4251']
+  foreach wd : ['/FImsvc_recommended_pragmas.h', '/wd4267', '/wd4530', '/wd4251', '/wd4273', '/wd4275']
     disabled_warning = cpp_compiler.get_supported_arguments(wd)
     add_project_arguments(disabled_warning, language: 'cpp')
   endforeach

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,18 @@
+option('maintainer-mode', type: 'combo', choices: ['false', 'if-git-build', 'true'],
+  value: 'if-git-build', description: 'Let mm-common-get copy some files to untracked/')
+option('warnings', type: 'combo', choices: ['no', 'min', 'max', 'fatal'],
+  value: 'min', description: 'Compiler warning level')
+option('dist-warnings', type: 'combo', choices: ['no', 'min', 'max', 'fatal'],
+  value: 'fatal', description: 'Compiler warning level when a tarball is created')
+option('build-deprecated-api', type: 'boolean', value: true,
+  description: 'Build deprecated API and include it in the library')
+option('build-documentation', type: 'combo', choices: ['false', 'if-maintainer-mode', 'true'],
+  value: 'if-maintainer-mode', description: 'Build and install the documentation')
+option('validation', type: 'boolean', value: true,
+  description: 'Validate the tutorial XML file')
+option('build-pdf', type: 'boolean', value: false,
+  description: 'Build tutorial PDF file')
+option('build-examples', type: 'boolean', value: true,
+  description: 'Build example programs')
+option('build-tests', type: 'boolean', value: true,
+  description: 'Build test programs')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,33 @@
+# tests
+
+# Input: xmlxx_dep, build_tests
+# Output: -
+
+test_programs = [
+# [[dir-name], exe-name, [sources]]
+  [['saxparser_chunk_parsing_inconsistent_state'], 'test', ['main.cc']],
+  [['saxparser_parse_double_free'], 'test', ['main.cc']],
+  [['saxparser_parse_stream_inconsistent_state'], 'test', ['main.cc']],
+]
+
+foreach ex : test_programs
+  dir = ''
+  foreach dir_part : ex[0]
+    dir = dir / dir_part
+  endforeach
+  ex_name = (dir / ex[1]).underscorify()
+  ex_sources = []
+  foreach src : ex[2]
+    ex_sources += dir / src
+  endforeach
+
+  exe_file = executable(ex_name, ex_sources,
+    dependencies: xmlxx_dep,
+    gui_app: false,
+    build_by_default: build_tests
+  )
+
+  if build_tests
+    test(ex_name, exe_file)
+  endif
+endforeach

--- a/tools/build_scripts/tutorial-custom-cmd.py
+++ b/tools/build_scripts/tutorial-custom-cmd.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+
+# External command, intended to be called with custom_target() in meson.build
+
+#                           argv[1]   argv[2:]
+# tutorial-custom-cmd.py <subcommand> <xxx>...
+
+import os
+import sys
+import subprocess
+from pathlib import Path
+import shutil
+
+subcommand = sys.argv[1]
+
+def insert_example_code():
+  #      argv[2]            argv[3]             argv[4]         argv[5]
+  # <perl_script_file> <examples_dir> <input_xml_file> <output_xml_file>
+
+  perl_script_file = sys.argv[2]
+  examples_dir = sys.argv[3]
+  input_xml_file = sys.argv[4]
+  output_xml_file = sys.argv[5]
+
+  cmd = [
+    'perl',
+    '--',
+    perl_script_file,
+    examples_dir,
+    input_xml_file,
+  ]
+  with open(output_xml_file, mode='w') as xml_file:
+    return subprocess.run(cmd, stdout=xml_file).returncode
+
+def html():
+  #      argv[2]          argv[3]         argv[4]
+  # <xslt_stylesheet> <input_xml_file> <output_html_dir>
+
+  xslt_stylesheet = sys.argv[2]
+  input_xml_file = sys.argv[3]
+  output_html_dir = sys.argv[4]
+
+  # Remove old files and create the destination directory.
+  shutil.rmtree(output_html_dir, ignore_errors=True)
+  os.makedirs(output_html_dir, exist_ok=True)
+
+  cmd = [
+    'xsltproc',
+    '-o', output_html_dir + '/',
+    '--xinclude',
+    '--catalogs',
+    xslt_stylesheet,
+    input_xml_file,
+  ]
+  result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                          universal_newlines=True)
+  # xsltproc prints the names of all written files. Don't print those lines.
+  for line in result.stdout.splitlines():
+    if not line.startswith('Writing '):
+      print(line)
+
+  return result.returncode
+
+def xmllint():
+  #  argv[2]       argv[3]          argv[4]
+  # <validate> <input_xml_file> <stamp_file_path>
+
+  validate = sys.argv[2]
+  input_xml_file = sys.argv[3]
+  stamp_file_path = sys.argv[4]
+
+  cmd = [
+    'xmllint',
+    '--noout',
+    '--noent',
+    '--xinclude',
+  ]
+  if validate == 'true':
+    cmd += ['--postvalid']
+  cmd += [input_xml_file]
+  result = subprocess.run(cmd)
+  if result.returncode:
+    return result.returncode
+
+  Path(stamp_file_path).touch(exist_ok=True)
+  return 0
+
+def dblatex():
+  #      argv[2]        argv[3]
+  # <input_xml_file> <output_pdf_file>
+  # Create a PDF file, using dblatex.
+
+  input_xml_file = sys.argv[2]
+  output_pdf_file = sys.argv[3]
+
+  # For a list of available parameters, see http://dblatex.sourceforge.net/doc/manual/
+  dblatex_params = [
+    '-P', 'toc.section.depth=2',
+    '-P', 'paper.type=a4paper',
+  ]
+
+  cmd = [
+    'dblatex',
+  ] + dblatex_params + [
+    '-o', output_pdf_file,
+    '--pdf', input_xml_file,
+  ]
+  return subprocess.run(cmd).returncode
+
+def docbook2pdf():
+  #      argv[2]        argv[3]
+  # <input_xml_file> <output_pdf_file>
+  # Create a PDF file, using docbook2pdf.
+
+  input_xml_file = sys.argv[2]
+  output_pdf_file = sys.argv[3]
+
+  output_dir = os.path.dirname(output_pdf_file)
+  if not output_dir:
+    output_dir = '.'
+  output_basename = os.path.basename(output_pdf_file)
+  if output_basename.endswith('.pdf'):
+    output_basename = output_basename[:-4]
+  xml_file = os.path.join(output_dir, output_basename + '.xml')
+
+  # We need to produce a full examples XML with all of the XIncludes done.
+  cmd = [
+    'xmllint',
+    '--xinclude',
+    '--postvalid',
+    '--output', xml_file,
+    input_xml_file,
+  ]
+  result = subprocess.run(cmd)
+  if result.returncode:
+    return result.returncode
+
+  cmd = [
+    'docbook2pdf',
+    '--output', output_dir,
+    xml_file,
+  ]
+  return subprocess.run(cmd).returncode
+
+# Invoked from meson.add_dist_script().
+def dist_doc():
+  #    argv[2]        argv[3]        argv[4]    argv[5]
+  # <doc_dist_dir> <doc_build_dir> <xml_file> <pdf_file>
+
+  # <doc_dist_dir> is a distribution directory, relative to MESON_DIST_ROOT.
+  # <doc_build_dir> is a relative or absolute path in the build directory.
+  # <xml_file> is a relative or absolute path in the build directory.
+  # <pdf_file> is a relative or absolute path in the build directory.
+  doc_dist_dir = os.path.join(os.getenv('MESON_DIST_ROOT'), sys.argv[2])
+  doc_build_dir = sys.argv[3]
+  xml_file = sys.argv[4]
+  pdf_file = sys.argv[5]
+
+  # Create the distribution directory, if it does not exist.
+  os.makedirs(doc_dist_dir, exist_ok=True)
+
+  # Distribute built XML file with example code inserted.
+  shutil.copy(xml_file, doc_dist_dir)
+
+  # Distribute built html files.
+  shutil.copytree(os.path.join(doc_build_dir, 'html'),
+                  os.path.join(doc_dist_dir, 'html'),
+                  copy_function=shutil.copy)
+
+  # If there is an updated PDF file, distribute it.
+  if os.path.isfile(pdf_file) and \
+     os.stat(pdf_file).st_mtime > os.stat(xml_file).st_mtime:
+    shutil.copy(pdf_file, doc_dist_dir)
+  else:
+    print('--- Info: No updated PDF file found.')
+
+  return 0
+
+# ----- Main -----
+if subcommand == 'insert_example_code':
+  sys.exit(insert_example_code())
+if subcommand == 'html':
+  sys.exit(html())
+if subcommand == 'xmllint':
+  sys.exit(xmllint())
+if subcommand == 'dblatex':
+  sys.exit(dblatex())
+if subcommand == 'docbook2pdf':
+  sys.exit(docbook2pdf())
+if subcommand == 'dist_doc':
+  sys.exit(dist_doc())
+print(sys.argv[0], ': illegal subcommand,', subcommand)
+sys.exit(1)

--- a/tools/conf_tests/have_exception_ptr.cc
+++ b/tools/conf_tests/have_exception_ptr.cc
@@ -1,0 +1,20 @@
+// Configuration-time test program, used in Meson build.
+// Test whether std::exception_ptr, std::current_exception() and
+// std::rethrow_exception() are defined.
+// Corresponds to the M4 macro LIBXMLXX_CXX_HAS_EXCEPTION_PTR.
+
+#include <exception>
+
+int main()
+{
+  try
+  {
+    throw "custom error";
+  }
+  catch (...)
+  {
+    std::exception_ptr ep = std::current_exception();
+    std::rethrow_exception(ep);
+  }
+  return 0;
+}

--- a/untracked/README
+++ b/untracked/README
@@ -1,0 +1,35 @@
+untracked/README
+
+This directory contains files not tracked by a source code control program,
+such as git. (This README file is the exception.)
+
+The files can have one of two origins.
+
+1. Copied by the mm-common-get command.
+2. Generated when libxml++ is built.
+
+Files of type 2 exist here only if libxml++ is built with maintainer-mode=false,
+or the directory comes from a tarball.
+Files of both types exist here only if libxml++ is built with Meson,
+or the tarball is created with Meson.
+
+1. Files copied by mm-common-get
+--------------------------------
+untracked/docs/doc-install.pl
+               doc-postprocess.pl
+               doxygen-extra.css
+               tagfile-to-devhelp2.xsl
+untracked/build_scripts/dist-build-scripts.py
+                        dist-changelog.py
+                        doc-reference.py
+
+mm-common-get may copy more files, but they are not used by libxml++.
+
+2. Generated files
+------------------
+untracked/docs/reference/libxml++-3.0.devhelp2
+                         libxml++-3.0.tag
+                         html/*
+untracked/docs/manual/libxml++.pdf (only if build-pdf=true)
+                      libxml++.xml
+                      html/*


### PR DESCRIPTION
This PR shows how libxml++-3.0 can be built with Meson instead of Autotools.
It's similar to the Meson build system in sigc++-3.0. No built sources.

I don't understand how LIBXMLXX_STATIC is supposed to work in libxml++config.h.
Is it ever defined anywhere? I haven't tried to define it in a meson.build file.
Some modules are different. Take gtkmm as an example. GTKMM_STATIC_LIB is defined
in the gtkmmconfig.h file when a static library is built.
Both configure.ac, gdk/meson.build and MSVC_NMake/generate-msvc.mak have code
that takes care of GTKMM_STATIC_LIB. Not so in libxml++.

Shall the generated files MSVC_NMake/libxml++/libxml++.rc and MSVC_NMake/libxml++/libxml++config.h
be included in distributed tarballs? They are listed in MSVC_MNake/filelist.am.
Some other modules, e.g. gtkmm, distribute similar files when a tarball is created
with Autotools, but not when it's created with Meson. In libsigc++, such files are
distributed both by Autotools and by Meson. 

@fanc999 Can you have a look at this, please.

I suppose you can't add commits to the kjellahl/meson-build-3-2 branch.
You can attach patch files to this PR, if you like.