### PR TITLE
Add Visual Studio build support for Meson builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,7 @@ LT_PREREQ([2.2.6])
 LT_INIT([dlopen win32-dll disable-static])
 
 AC_SUBST([LIBXMLXX_MODULES], ['libxml-2.0 >= 2.7.7 glibmm-2.4 >= 2.32.0'])
+AC_SUBST([LIBXML2_LIB_NO_PKGCONFIG], [''])
 PKG_CHECK_MODULES([LIBXMLXX], [$LIBXMLXX_MODULES])
 
 AC_LANG([C++])

--- a/libxml++.pc.in
+++ b/libxml++.pc.in
@@ -15,5 +15,5 @@ Description: C++ wrapper for libxml
 Version: @PACKAGE_VERSION@
 URL: http://libxmlplusplus.sourceforge.net/
 Requires: @LIBXMLXX_MODULES@
-Libs: -L${libdir} -lxml++-@LIBXMLXX_API_VERSION@
+Libs: -L${libdir} -lxml++-@LIBXMLXX_API_VERSION@ @LIBXML2_LIB_NO_PKGCONFIG@
 Cflags: -I${includedir}/@LIBXMLXX_MODULE_NAME@ -I${libdir}/@LIBXMLXX_MODULE_NAME@/include

--- a/libxml++/meson.build
+++ b/libxml++/meson.build
@@ -84,7 +84,7 @@ foreach dir_files : xmlxx_subdir_h_cc_files
   install_headers(subdir_h_files, subdir: xmlxx_pcname / 'libxml++' / dir)
 endforeach
 
-xmlxx_cpp_args = [ '-LIBXMLPP_BUILD=1' ]
+xmlxx_cpp_args = [ '-DLIBXMLPP_BUILD=1' ]
 
 # Make sure we are exporting the symbols from the DLL
 if is_msvc

--- a/meson.build
+++ b/meson.build
@@ -94,90 +94,66 @@ install_pkgconfigdir = install_libdir / 'pkgconfig'
 # for its pkg-config files on Visual Studio as well
 glibmm_req = '>= 2.32.0'
 
-# libxml-2.0 supported pkg-config files on MSVC files for a good while, so just use that
-xml2_req = '>= 2.7.7'
-xml2_dep = dependency('libxml-2.0', version: xml2_req)
+# libxml2's Windows-specific Makefiles don't create pkg-config files for us, so
+# we may need to look for it manually on Windows
+xml2_min_ver = '2.7.7'
+xml2_req = '>= @0@'.format(xml2_min_ver)
+xml2_dep = dependency('libxml-2.0', version: xml2_req, required: host_machine.system() != 'windows')
+
+if not xml2_dep.found()
+  libxml2_lib = 'libxml2'
+  xml2_dep =  cpp_compiler.find_library(libxml2_lib,
+                                        has_headers: [
+                                          'libxml/globals.h',
+                                          'libxml/parser.h',
+                                          'libxml/parserInternals.h',
+                                          'libxml/relaxng.h',
+                                          'libxml/tree.h',
+                                          'libxml/xinclude.h',
+                                          'libxml/xpath.h',
+                                          'libxml/xpathInternals.h',
+                                          'libxml/xmlerror.h',
+                                          'libxml/xmlIO.h',
+                                          'libxml/xmlreader.h',
+                                          'libxml/xmlschemas.h',
+                                        ])
+
+    xml_min_ver_split = xml2_min_ver.split('.')
+    xml_min_ver_int = xml_min_ver_split[0].to_int() * 10000 + \
+                      xml_min_ver_split[1].to_int() * 100 + \
+                      xml_min_ver_split[2].to_int()
+
+    if not cpp_compiler.compiles('''#include <libxml/tree.h>
+                                    #if LIBXML_VERSION < @0@
+                                    # error libxml2 versions must be @1@ or later
+                                    #endif'''.format(xml_min_ver_int.to_string(), xml2_min_ver),
+                                    name : 'libxml2 is @0@ or later'.format(xml2_min_ver))
+      error('Your libxml2 installation must be @0@ or later'.format(xml2_min_ver))
+    endif
+endif
 
 # The -mm libraries do not yet have pkg-config files for MSVC builds,
 # so check for them manually
 glibmm_req_minor_ver = '4'
 
-glibmm_dep = dependency('glibmm-2.@0@'.format(glibmm_req_minor_ver), version: glibmm_req, required: not is_msvc)
+glibmm_dep = dependency('glibmm-2.@0@'.format(glibmm_req_minor_ver), version: glibmm_req)
 
-if is_msvc
-  # We must have Visual Studio 2013 or later...
-  assert(cpp_compiler.version().split('.')[0].to_int() >= 18, 'Visual Studio 2013 or later is required')
+xmlxx_requires = ''
+libxml2_lib_pkgconfig = ''
 
-  sigc_major_ver = '2'
-
-  if not glibmm_dep.found()
-    assert(cpp_compiler.has_header('sigc++-@0@.0/sigc++/sigc++.h'.format(sigc_major_ver)) and cpp_compiler.has_header('sigc++-@0@.0/include/sigc++config.h'.format(sigc_major_ver)),
-           'sigc++-@0@.x headers are required'.format(sigc_major_ver))
-    assert(cpp_compiler.has_header('glibmm-2.@0@/glibmm.h'.format(glibmm_req_minor_ver)) and cpp_compiler.has_header('glibmm-2.@0@/include/glibmmconfig.h'.format(glibmm_req_minor_ver)),
-           'glibmm-2.@0@ headers are required'.format(glibmm_req_minor_ver))
-
-  else
-    sigc_dep = dependency('', required: false) # glibmm covers for libsigc++ in its pkg-config file
-  endif
-  message('Ensure your INCLUDE and LIB contain the paths that lead to the appropriate headers and .lib\'s for glibmm-2.@0@ and libsigc++-2.x'.format(glibmm_req_minor_ver))
-
-  # We need to look for appropriate versions of Visual
-  # Studio since those built by NMake and the former
-  # Visual Studio projects are versioned by the VS versions
-  if cpp_compiler.version().split('.')[0].to_int() == 18
-    msvc_check_range = [12] # Visual Studio 2013
-    warning('Visual Studio 2013 must configure without -Dwarnings=fatal, which is the default')
-  elif cpp_compiler.version().split('.')[0].to_int() == 19
-    # Visual Studio 2019 can consume libraries built with 2017 and 2015
-    # and Visual Studio 2017 can consume libraries built with 2015
-    msvc_check_range = [14] # Visual Studio 2015, 2017, 2019
-    message('It is safe to ignore warnings from Meson that MSVC does not support C++11')
-  endif
-
-  debugsuffix = ''
-  if get_option('buildtype') == 'debug'
-    debugsuffix = '-d'
-  endif
-
-  # We can be looking for MSVC 2015-built libraries on 2017 and 2019 builds as well,
-  # as well as 2017-built libraries on 2019 as well, so we can't just assume that
-  # libraries exist, but check that compatible versions are really found
-  foreach v : msvc_check_range
-    glibmm_dep = glibmm_dep.found() ? glibmm_dep : cpp_compiler.find_library('glibmm-vc@0@0@1@-2_@2@'.format(v.to_string(), debugsuffix, glibmm_req_minor_ver), required: false)
-  endforeach
-
-  if glibmm_dep.type_name() == 'library'
-    warning('Note: Be sure to check that this finds the same libsigc++ .lib your glibmm is linked to')
-    sigc_dep = cpp_compiler.find_library('sigc-@0@.0'.format(sigc_major_ver), required: false)
-    foreach v : msvc_check_range
-      sigc_dep = sigc_dep.found() ? sigc_dep : cpp_compiler.find_library('sigc-vc@0@0@1@-2_0'.format(v.to_string(), debugsuffix), required: false)
-    endforeach
-  endif
-
-  # Now make sure the appropriate -mm libraries are found
-  assert(glibmm_dep.found() and (glibmm_dep.type_name() == 'pkgconfig' or sigc_dep.found()), 'Appropriate glibmm-vcxx0@0@-2_@1@.lib and sigc-vcxx0@0@-@2@_0.lib are required'.format(debugsuffix, glibmm_req_minor_ver, sigc_major_ver))
-
-  # Put glibmm in the required packages if we find it by pkg-config
-  mm_lib_requires = ''
-  if glibmm_dep.type_name() == 'pkgconfig'
-    mm_lib_requires += ' '.join([
-      'glibmm-2.@0@'.format(glibmm_req_minor_ver), glibmm_req,
-    ]) + ' '
-  endif
-
-  xmlxx_requires = mm_lib_requires + ' '.join([
-    'libxml-2.0', xml2_req,
-  ])
-
-  xmlxx_build_dep = [glibmm_dep, sigc_dep, xml2_dep]
+# Put libxml-2.0 in the 'Requires:' section in the generated pkg-config file if
+# we found it by pkg-config
+if xml2_dep.type_name() == 'pkgconfig'
+  xmlxx_requires += ' '.join(['libxml-2.0', xml2_req]) + ' '
 else
-  # not MSVC
-  xmlxx_build_dep = [xml2_dep, glibmm_dep]
-  xmlxx_requires = ' '.join([
-    'libxml-2.0', xml2_req,
-    'glibmm-2.@0@'.format(glibmm_req_minor_ver), glibmm_req,
-  ])
+  libxml2_lib_pkgconfig = '-l@0@'.format(libxml2_lib)
 endif
+
+# ...Then put glibmm-2.x in the 'Requires:' section in the generated pkg-config file
+xmlxx_requires += ' '.join(['glibmm-2.@0@'.format(glibmm_req_minor_ver), glibmm_req])
+
+# Make sure we link to libxml-2.0 and glibmm
+xmlxx_build_dep = [xml2_dep, glibmm_dep]
 
 # Some dependencies are required only in maintainer mode and/or if
 # reference documentation shall be built.
@@ -275,6 +251,7 @@ pkg_conf_data.set('PACKAGE_VERSION', meson.project_version())
 pkg_conf_data.set('LIBXMLXX_MODULE_NAME', xmlxx_pcname)
 pkg_conf_data.set('LIBXMLXX_API_VERSION', xmlxx_api_version)
 pkg_conf_data.set('LIBXMLXX_MODULES', xmlxx_requires)
+pkg_conf_data.set('LIBXML2_LIB_NO_PKGCONFIG', libxml2_lib_pkgconfig)
 
 if not build_deprecated_api
   pkg_conf_data.set('LIBXMLXX_DISABLE_DEPRECATED', 1)

--- a/meson.build
+++ b/meson.build
@@ -231,7 +231,7 @@ add_project_arguments(warning_flags, language: 'cpp')
 # MSVC: Ignore warnings that aren't really harmful, but make those
 #       that should not be overlooked stand out.
 if is_msvc
-  foreach wd : ['/FImsvc_recommended_pragmas.h', '/wd4267', '/wd4530', '/wd4251']
+  foreach wd : ['/FImsvc_recommended_pragmas.h', '/wd4267', '/wd4530', '/wd4251', '/wd4273', '/wd4275']
     disabled_warning = cpp_compiler.get_supported_arguments(wd)
     add_project_arguments(disabled_warning, language: 'cpp')
   endforeach


### PR DESCRIPTION
Hi,

This updates the proposed Meson build files for libxml++-3.x so that we can also support Visual Studio builds with the Meson build files, by:

*  Looking for libxml2 manually on Windows also, since the specific Windows build files for libxml2 (Visual C++ and MinGW, if the MinGW builds were not done via autotools) do not generate pkg-config files for us.  Also make sure we generate the pkg-config file for libxml++ accordingly, by whether we found libxml2 via pkg-config or manually.

*  Looking for glibmm (and therefore libsigc++) with pkg-config for all builds, since Meson build support is in place.

*  Fixing a typo: `-LIBXMLPP_BUILD=1` to `-DLIBXMLPP_BUILD=1`, which caused Visual Studio builds to break.

*  Silence some more compiler warnings.

One question, though: It was found that when building libxml++ against glibmm, there is an unfortunate corner case that made the linked glibmm ABI incompatible with the libxml++ DLL that we are building, if glibmm and libxml++ are built with different Visual Studio versions, causing linker errors (even between Visual Studio 2015, 2017 and 2019, which Microsoft tried hard to make them ABI compatible), I opened up two MRs in glibmm, one for `glibmm-2-64` and another for `master`, so that the built .lib and .dll files contain the toolset version within their filenames, shall we try to do the same for the rest of the gtkmm stack and for libxml++ as well.  It seems that libsigc++ does not suffer from this problem, but gtkmm gets hit by this as well (but seemingly not pangomm, cairomm and atkmm).

With blessings, thank you!