### PR TITLE
Meson/Visual Studio builds: Use toolset version by default (libxml++-3-2 branch)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,7 @@ LT_INIT([dlopen win32-dll disable-static])
 
 AC_SUBST([LIBXMLXX_MODULES], ['libxml-2.0 >= 2.7.7 glibmm-2.4 >= 2.32.0'])
 AC_SUBST([LIBXML2_LIB_NO_PKGCONFIG], [''])
+AC_SUBST([MSVC_TOOLSET_VER], [''])
 PKG_CHECK_MODULES([LIBXMLXX], [$LIBXMLXX_MODULES])
 
 AC_LANG([C++])

--- a/libxml++.pc.in
+++ b/libxml++.pc.in
@@ -15,5 +15,5 @@ Description: C++ wrapper for libxml
 Version: @PACKAGE_VERSION@
 URL: http://libxmlplusplus.sourceforge.net/
 Requires: @LIBXMLXX_MODULES@
-Libs: -L${libdir} -lxml++-@LIBXMLXX_API_VERSION@ @LIBXML2_LIB_NO_PKGCONFIG@
+Libs: -L${libdir} -lxml++@MSVC_TOOLSET_VER@-@LIBXMLXX_API_VERSION@ @LIBXML2_LIB_NO_PKGCONFIG@
 Cflags: -I${includedir}/@LIBXMLXX_MODULE_NAME@ -I${libdir}/@LIBXMLXX_MODULE_NAME@/include

--- a/libxml++/meson.build
+++ b/libxml++/meson.build
@@ -1,7 +1,7 @@
 # libxml++
 
 # Input: xmlxx_build_dep, xmlxx_pcname, xmlxx_libversion, xmlxx_api_version,
-#        install_includedir, xmlxx_rc
+#        install_includedir, xmlxx_rc, xmlxx_libname
 # Output: source_h_files, xmlxx_dep
 
 # There are no built source files in libxml++-3.0.
@@ -101,7 +101,7 @@ if host_machine.system() == 'windows'
 endif
 
 extra_include_dirs = ['..']
-xmlxx_library = library('xml++-' + xmlxx_api_version,
+xmlxx_library = library(xmlxx_libname,
   source_cc_files,
   extra_xmlxx_objects,
   version: xmlxx_libversion,

--- a/meson.build
+++ b/meson.build
@@ -78,6 +78,8 @@ build_documentation = build_documentation_opt == 'true' or \
 build_examples = get_option('build-examples')
 build_tests = get_option('build-tests')
 
+use_msvc14x_toolset_ver = get_option('msvc14x-parallel-installable')
+
 # Installation directories are relative to {prefix}.
 install_prefix = get_option('prefix')
 install_includedir = get_option('includedir')
@@ -193,9 +195,22 @@ endif
 xmlxx_script_dir = project_source_root / 'tools' / 'build_scripts'
 tutorial_custom_cmd_py = xmlxx_script_dir / 'tutorial-custom-cmd.py'
 
+# Add toolset version in builds done with Visual Studio 2017 or later
+msvc14x_toolset_ver = ''
+
 if is_msvc
   add_project_arguments(cpp_compiler.get_supported_arguments([ '/utf-8', '/wd4828']), language: 'cpp')
+
+  if use_msvc14x_toolset_ver
+    if cpp_compiler.version().version_compare('>=19.20')
+      msvc14x_toolset_ver = '-vc142'
+    elif cpp_compiler.version().version_compare('>=19.10')
+      msvc14x_toolset_ver = '-vc141'
+    endif
+  endif
 endif
+
+xmlxx_libname = 'xml++' + msvc14x_toolset_ver + '-' + xmlxx_api_version
 
 # Set compiler warnings.
 warning_flags = []
@@ -251,6 +266,7 @@ pkg_conf_data.set('LIBXMLXX_MODULE_NAME', xmlxx_pcname)
 pkg_conf_data.set('LIBXMLXX_API_VERSION', xmlxx_api_version)
 pkg_conf_data.set('LIBXMLXX_MODULES', xmlxx_requires)
 pkg_conf_data.set('LIBXML2_LIB_NO_PKGCONFIG', libxml2_lib_pkgconfig)
+pkg_conf_data.set('MSVC_TOOLSET_VER', msvc14x_toolset_ver)
 
 if not build_deprecated_api
   pkg_conf_data.set('LIBXMLXX_DISABLE_DEPRECATED', 1)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -16,3 +16,5 @@ option('build-examples', type: 'boolean', value: true,
   description: 'Build example programs')
 option('build-tests', type: 'boolean', value: true,
   description: 'Build test programs')
+option('msvc14x-parallel-installable', type: 'boolean', value: true,
+  description: 'Use separate DLL and LIB filenames for Visual Studio 2017 and 2019')


### PR DESCRIPTION
Hi,

This is a follow-up from PR #17.  From the commit message:

<i>Like the NMake Makefiles, put in the toolset version of Visual Studio in the filenames of the built DLL and .lib by default on Visual Studio 2017 and 2019, so that it makes it easier to share the same glib, libxml and libsigc++ DLLs and libraries that were built with Visual Studio 2015~2019.</i>

<i>The reasoning behind this change here is because although Microsoft tried very hard to make DLLs built with Visual Studio 2015, 2017 and 2019 API and ABI compatible, but libxml++ hits a corner case with glibmm where this compatibility does not work, but then the libxml, glib and libsigc++ DLLs and .lib's are indeed ABI-compatible.</i>

With blessings, thank you!