### PR TITLE
update meson_version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ project('libxml++', 'cpp',
   default_options: [
     'cpp_std=c++17'
   ],
-  meson_version: '>= 0.55.0', # required for meson.add_dist_script(python3, ...)
+  meson_version: '>= 0.58.0', # required for meson.add_dist_script(python3, ...)
                               # and meson.add_install_script(python3, ...)
 )
 


### PR DESCRIPTION
add_dist_script in a subproject became available in 0.58.0

WARNING: Project targeting '>= 0.54.0' but tried to use feature introduced in '0.58.0': Calling "add_dist_script" in a subproject.