### PR TITLE
Allow static linking on Windows

### DIFF
--- a/libxml++/meson.build
+++ b/libxml++/meson.build
@@ -88,7 +88,7 @@ endforeach
 xmlxx_cpp_args = [ '-DLIBXMLPP_BUILD=1' ]
 
 # Make sure we are exporting the symbols from the DLL
-if is_msvc
+if is_msvc and get_option('default_library') != 'static'
   xmlxx_cpp_args += ['-D_WINDLL']
 endif
 

--- a/libxml++config.h.meson
+++ b/libxml++config.h.meson
@@ -16,6 +16,8 @@
 /* Micro version number of libxml++. */
 #mesondefine LIBXMLXX_MICRO_VERSION
 
+#mesondefine LIBXMLXX_STATIC
+
 // Enable DLL-specific stuff only when not building a static library
 #if !defined(__CYGWIN__) && (defined(__MINGW32__) || defined(_MSC_VER)) && !defined(LIBXMLXX_STATIC)
 # define LIBXMLPP_DLL 1

--- a/meson.build
+++ b/meson.build
@@ -325,10 +325,12 @@ endif
 
 # Static library?
 library_build_type = get_option('default_library')
+pkg_conf_data.set('LIBXMLXX_STATIC', library_build_type == 'static')
+
 
 if cpp_compiler.get_argument_syntax() == 'msvc'
-  if library_build_type == 'static' or library_build_type == 'both'
-    error('Static builds are not supported by MSVC-style builds')
+  if library_build_type == 'both'
+    error('Dynamic+Static builds are not supported by MSVC-style builds')
   endif
 endif
 


### PR DESCRIPTION
I'm not sure why the static build was disabled on Windows... but it seems to work now at least.

- Sets the missing define in libxml++config.h
- Add libxml2 wrap, but continue to use the older library logic and only fallback to the wrap when we have to
- add a workflow to build a static windows library. [Here's a link](https://github.com/talisein/libxmlplusplus/actions/runs/2500837381) to a passing run.

