### PR TITLE
Fix building istream_ioparser test on Visual Studio

### DIFF
--- a/tests/istream_ioparser/main.cc
+++ b/tests/istream_ioparser/main.cc
@@ -17,6 +17,7 @@
 
 #include <libxml++/libxml++.h>
 
+#include <algorithm>
 #include <cassert>
 #include <cstdlib>
 #include <cstring>


### PR DESCRIPTION
Hi,

This is a simple fix for building the istream_ioparser test on Visual Studio, where `<algorithm>` needs to be included in order to use `std::min()`.

With blessings, thank you!