### PR TITLE
clang-tidy: use make_unique

### DIFF
--- a/libxml++/parsers/parser.cc
+++ b/libxml++/parsers/parser.cc
@@ -227,9 +227,9 @@ void Parser::check_for_error_and_warning_messages()
   }
 
   if (validity_msg)
-    exception_.reset(new validity_error(msg));
+    exception_ = std::make_unique<validity_error>(msg);
   else if (parser_msg)
-    exception_.reset(new parse_error(msg));
+    exception_ = std::make_unique<parse_error>(msg);
 }
 
 //static
@@ -331,7 +331,7 @@ void Parser::handle_exception()
 #ifdef LIBXMLXX_HAVE_EXCEPTION_PTR
   catch (...)
   {
-    exception_.reset(new wrapped_exception(std::current_exception()));
+    exception_ = std::make_unique<wrapped_exception>(std::current_exception());
   }
 #else
   catch (const std::exception& e)

--- a/libxml++/parsers/saxparser.cc
+++ b/libxml++/parsers/saxparser.cc
@@ -333,7 +333,7 @@ void SaxParser::initialize_context()
 {
   Parser::initialize_context();
   // Start with an empty Document for entity resolution.
-  entity_resolver_doc_.reset(new Document);
+  entity_resolver_doc_ = std::make_unique<Document>();
 }
 
 

--- a/libxml++/validators/validator.cc
+++ b/libxml++/validators/validator.cc
@@ -68,7 +68,7 @@ void Validator::check_for_validity_messages()
   }
 
   if (validity_msg)
-    exception_.reset(new validity_error(msg));
+    exception_ = std::make_unique<validity_error>(msg);
 }
 
 void Validator::callback_validity_error(void* valid_, const char* msg, ...)
@@ -130,17 +130,17 @@ void Validator::handle_exception()
 #ifdef LIBXMLXX_HAVE_EXCEPTION_PTR
   catch (...)
   {
-    exception_.reset(new wrapped_exception(std::current_exception()));
+    exception_ = std::make_unique<wrapped_exception>(std::current_exception());
   }
 #else
   catch (const std::exception& e)
   {
-    exception_.reset(new exception(e.what()));
+    exception_ = std::make_unique<exception>(e.what());
   }
   catch (...)
   {
-    exception_.reset(new exception("An exception was thrown that is not derived from std::exception or xmlpp::exception.\n"
-      "It could not be caught and rethrown because this platform does not support std::exception_ptr."));
+    exception_ = std::make_unique<exception>("An exception was thrown that is not derived from std::exception or xmlpp::exception.\n"
+      "It could not be caught and rethrown because this platform does not support std::exception_ptr.");
   }
 #endif
 


### PR DESCRIPTION
Found with modernize-make-unique

Signed-off-by: Rosen Penev <rosenp@gmail.com>