### PR TITLE
clang-tidy: remove pessimising const

### DIFF
--- a/libxml++/attributenode.cc
+++ b/libxml++/attributenode.cc
@@ -28,7 +28,7 @@ ustring AttributeNode::get_value() const
   else
     value = xmlGetNoNsProp(cobj()->parent, cobj()->name);
 
-  const ustring retn = value ? (const char*)value : "";
+  ustring retn = value ? (const char*)value : "";
   if (value)
     xmlFree(value);
   return retn;

--- a/libxml++/nodes/node.cc
+++ b/libxml++/nodes/node.cc
@@ -206,7 +206,7 @@ xmlpp::ustring eval_common_to_string(const xmlpp::ustring& xpath,
   xmlXPathFreeObject(xpath_value);
   if (result)
   {
-    const xmlpp::ustring uresult(reinterpret_cast<const char*>(result));
+    xmlpp::ustring uresult(reinterpret_cast<const char*>(result));
     xmlFree(result);
     return uresult;
   }

--- a/libxml++/parsers/textreader.cc
+++ b/libxml++/parsers/textreader.cc
@@ -410,7 +410,7 @@ ustring TextReader::PropertyReader::String(xmlChar* value, bool free)
   if (!value)
     return ustring();
 
-  const ustring result = (char *)value;
+  ustring result = (char *)value;
 
   if(free)
     xmlFree(value);


### PR DESCRIPTION
Found with performance-no-automatic-move

Signed-off-by: Rosen Penev <rosenp@gmail.com>