### PR TITLE
clang-tidy: use const ref for exeption_ptr

### DIFF
--- a/examples/dom_parser/main.cc
+++ b/examples/dom_parser/main.cc
@@ -65,9 +65,8 @@ void print_node(const xmlpp::Node* node, unsigned int indentation = 0)
   else if(nodeContent)
   {
     std::cout << indent << "content = " << nodeContent->get_content() << std::endl;
-  }
-  else if(const xmlpp::Element* nodeElement = dynamic_cast<const xmlpp::Element*>(node))
-  {
+  } else if (const auto nodeElement =
+                 dynamic_cast<const xmlpp::Element *>(node)) {
     //A normal Element node:
 
     //line() works only for ElementNodes.

--- a/examples/dom_xinclude/main.cc
+++ b/examples/dom_xinclude/main.cc
@@ -64,9 +64,8 @@ void print_node(const xmlpp::Node* node, unsigned int indentation = 0)
   else if (nodeContent)
   {
     std::cout << indent << "content = " << nodeContent->get_content() << std::endl;
-  }
-  else if (const xmlpp::Element* nodeElement = dynamic_cast<const xmlpp::Element*>(node))
-  {
+  } else if (const auto nodeElement =
+                 dynamic_cast<const xmlpp::Element *>(node)) {
     //A normal Element node:
     std::cout << indent << "     Element line = " << node->get_line() << std::endl;
 
@@ -86,13 +85,9 @@ void print_node(const xmlpp::Node* node, unsigned int indentation = 0)
     {
       std::cout << indent << "title = " << attribute->get_value() << std::endl;
     }
-  }
-  else if (dynamic_cast<const xmlpp::XIncludeStart*>(node))
-  {
+  } else if (dynamic_cast<const xmlpp::XIncludeStart *>(node)) {
     std::cout << indent << "     " << "XIncludeStart line = " << node->get_line() << std::endl;
-  }
-  else if (dynamic_cast<const xmlpp::XIncludeEnd*>(node))
-  {
+  } else if (dynamic_cast<const xmlpp::XIncludeEnd *>(node)) {
     std::cout << indent << "     " << "XIncludeEnd" << std::endl;
   }
 

--- a/libxml++/nodes/node.cc
+++ b/libxml++/nodes/node.cc
@@ -463,7 +463,7 @@ ustring Node::get_namespace_prefix() const
   else if (impl_->type == XML_ATTRIBUTE_DECL)
   {
     //impl_ is actually of type xmlAttribute, instead of just xmlNode.
-    const xmlAttribute* const attr = reinterpret_cast<const xmlAttribute*>(impl_);
+    const auto attr = reinterpret_cast<const xmlAttribute *>(impl_);
     return attr->prefix ? (const char*)attr->prefix : "";
   }
   else if(impl_->ns && impl_->ns->prefix)

--- a/libxml++/parsers/domparser.cc
+++ b/libxml++/parsers/domparser.cc
@@ -180,7 +180,7 @@ namespace {
                                  char * buffer,
                                  int len)
     {
-      std::istream *in = static_cast<std::istream*>(context);
+      auto in = static_cast<std::istream *>(context);
       in->read(buffer, len);
       return in->gcount();
     }

--- a/libxml++/parsers/saxparser.cc
+++ b/libxml++/parsers/saxparser.cc
@@ -215,7 +215,7 @@ namespace {
                                  char * buffer,
                                  int len)
     {
-      std::istream *in = static_cast<std::istream*>(context);
+      auto in = static_cast<std::istream *>(context);
       in->read(buffer, len);
       return in->gcount();
     }

--- a/libxml++/validators/dtdvalidator.cc
+++ b/libxml++/validators/dtdvalidator.cc
@@ -164,8 +164,8 @@ void DtdValidator::validate(const Document* document)
   xmlResetLastError();
   initialize_context();
 
-  const bool res = (bool)xmlValidateDtd(pimpl_->context, (xmlDoc*)document->cobj(),
-                   pimpl_->dtd->cobj());
+  const auto res = (bool)xmlValidateDtd(
+      pimpl_->context, (xmlDoc *)document->cobj(), pimpl_->dtd->cobj());
 
   if (!res)
   {


### PR DESCRIPTION
Found with performance-unnecessary-value-param

Signed-off-by: Rosen Penev <rosenp@gmail.com>