### PR TITLE
clang-tidy: replace throw() with noexcept

### DIFF
--- a/examples/sax_exception/myparser.cc
+++ b/examples/sax_exception/myparser.cc
@@ -30,9 +30,7 @@ MyException::MyException()
 {
 }
 
-MyException::~MyException() throw ()
-{
-}
+MyException::~MyException() noexcept = default;
 
 void MyException::raise() const
 {


### PR DESCRIPTION
Found with modernize-use-noexcept

Signed-off-by: Rosen Penev <rosenp@gmail.com>