### PR TITLE
clang-tidy: use C++ headers

### DIFF
--- a/examples/dom_build/main.cc
+++ b/examples/dom_build/main.cc
@@ -21,9 +21,9 @@
 #include <config.h>
 #endif
 
-#include <libxml++/libxml++.h>
+#include <cstdlib>
 #include <iostream>
-#include <stdlib.h>
+#include <libxml++/libxml++.h>
 
 int
 main(int /* argc */, char** /* argv */)

--- a/examples/dom_parser_raw/main.cc
+++ b/examples/dom_parser_raw/main.cc
@@ -19,9 +19,9 @@
 
 #include <libxml++/libxml++.h>
 
-#include <iostream>
+#include <cstdlib>
 #include <fstream>
-#include <stdlib.h>
+#include <iostream>
 
 void print_node(const xmlpp::Node* node, unsigned int indentation = 0)
 {

--- a/examples/dom_read_write/main.cc
+++ b/examples/dom_read_write/main.cc
@@ -23,9 +23,9 @@
 #include <config.h>
 #endif
 
-#include <libxml++/libxml++.h>
+#include <cstdlib>
 #include <iostream>
-#include <stdlib.h>
+#include <libxml++/libxml++.h>
 
 int
 main(int argc, char* argv[])

--- a/examples/dom_xinclude/main.cc
+++ b/examples/dom_xinclude/main.cc
@@ -20,9 +20,9 @@
 #include <config.h>
 #endif
 
-#include <libxml++/libxml++.h>
+#include <cstdlib>
 #include <iostream>
-#include <stdlib.h>
+#include <libxml++/libxml++.h>
 
 void print_node(const xmlpp::Node* node, unsigned int indentation = 0)
 {

--- a/examples/dom_xpath/main.cc
+++ b/examples/dom_xpath/main.cc
@@ -21,9 +21,9 @@
 #include <config.h>
 #endif
 
-#include <libxml++/libxml++.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <iostream>
+#include <libxml++/libxml++.h>
 
 std::string result_type_to_ustring(xmlpp::XPathResultType result_type)
 {

--- a/examples/dtdvalidation/main.cc
+++ b/examples/dtdvalidation/main.cc
@@ -22,9 +22,9 @@
 #include <config.h>
 #endif
 
-#include <libxml++/libxml++.h>
+#include <cstdlib>
 #include <iostream>
-#include <stdlib.h>
+#include <libxml++/libxml++.h>
 
 int main(int argc, char* argv[])
 {

--- a/examples/sax_exception/main.cc
+++ b/examples/sax_exception/main.cc
@@ -26,8 +26,8 @@
 #endif
 
 #include "myparser.h"
+#include <cstdlib>
 #include <iostream>
-#include <stdlib.h>
 
 int main(int /* argc */, char** /* argv */)
 {

--- a/examples/sax_parser/main.cc
+++ b/examples/sax_parser/main.cc
@@ -21,10 +21,10 @@
 #include <config.h>
 #endif
 
+#include <cstdlib>
+#include <cstring> // std::memset()
 #include <fstream>
 #include <iostream>
-#include <stdlib.h>
-#include <cstring> // std::memset()
 
 #include "myparser.h"
 

--- a/examples/sax_parser_build_dom/main.cc
+++ b/examples/sax_parser_build_dom/main.cc
@@ -23,9 +23,9 @@
 #include <config.h>
 #endif
 
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
-#include <stdlib.h>
 
 #include "svgparser.h"
 #include "svgdocument.h"

--- a/examples/sax_parser_entities/main.cc
+++ b/examples/sax_parser_entities/main.cc
@@ -21,9 +21,9 @@
 #include <config.h>
 #endif
 
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
-#include <stdlib.h>
 
 #include "myparser.h"
 

--- a/examples/textreader/main.cc
+++ b/examples/textreader/main.cc
@@ -26,8 +26,8 @@
 #include <libxml++/libxml++.h>
 #include <libxml++/parsers/textreader.h>
 
+#include <cstdlib>
 #include <iostream>
-#include <stdlib.h>
 
 struct indent {
   int depth_;


### PR DESCRIPTION
Found with modernize-deprecated-headers

Signed-off-by: Rosen Penev <rosenp@gmail.com>