### PR TITLE
exceptions/exception.h: Try fixing linking on MinGW

### DIFF
--- a/libxml++/exceptions/exception.h
+++ b/libxml++/exceptions/exception.h
@@ -36,17 +36,17 @@ namespace xmlpp
 
 /** Base class for all xmlpp exceptions.
  */
-class exception : public std::exception
+class LIBXMLPP_VISIBILITY_DEFAULT exception : public std::exception
 {
 public:
-  LIBXMLPP_API
+  LIBXMLPP_MEMBER_METHOD
   explicit exception(const ustring& message);
-  LIBXMLPP_API ~exception() noexcept override;
+  LIBXMLPP_MEMBER_METHOD ~exception() noexcept override;
 
-  LIBXMLPP_API const char* what() const noexcept override;
+  LIBXMLPP_MEMBER_METHOD const char* what() const noexcept override;
 
-  LIBXMLPP_API virtual void raise() const;
-  LIBXMLPP_API virtual exception* clone() const;
+  LIBXMLPP_MEMBER_METHOD virtual void raise() const;
+  LIBXMLPP_MEMBER_METHOD virtual exception* clone() const;
 
 private:
   ustring message_;

--- a/libxml++config.h.in
+++ b/libxml++config.h.in
@@ -24,6 +24,10 @@
 #ifdef LIBXMLPP_DLL
   #ifdef LIBXMLPP_BUILD
     #define LIBXMLPP_API __declspec(dllexport)
+    #ifdef __GNUC__
+      #define LIBXMLPP_VISIBILITY_DEFAULT __attribute__((visibility("default")))
+      #define LIBXMLPP_MEMBER_METHOD
+    #endif
   #elif !defined (__GNUC__)
     #define LIBXMLPP_API __declspec(dllimport)
   #else /* don't dllimport classes/methods on GCC/MinGW */
@@ -33,6 +37,13 @@
   /* Build a static library or a non-Windows library*/
   #define LIBXMLPP_API
 #endif /* GLIBMM_DLL */
+
+#ifndef LIBXMLPP_VISIBILITY_DEFAULT
+  #define LIBXMLPP_VISIBILITY_DEFAULT
+#endif
+#ifndef LIBXMLPP_MEMBER_METHOD
+  #define LIBXMLPP_MEMBER_METHOD LIBXMLPP_API
+#endif
 
 #endif /* _LIBXMLPP_CONFIG_H */
 

--- a/libxml++config.h.meson
+++ b/libxml++config.h.meson
@@ -26,6 +26,10 @@
 #ifdef LIBXMLPP_DLL
   #ifdef LIBXMLPP_BUILD
     #define LIBXMLPP_API __declspec(dllexport)
+    #ifdef __GNUC__
+      #define LIBXMLPP_VISIBILITY_DEFAULT __attribute__((visibility("default")))
+      #define LIBXMLPP_MEMBER_METHOD
+    #endif
   #elif !defined (__GNUC__)
     #define LIBXMLPP_API __declspec(dllimport)
   #else /* don't dllimport classes/methods on GCC/MinGW */
@@ -35,6 +39,13 @@
   /* Build a static library or a non-Windows library*/
   #define LIBXMLPP_API
 #endif /* GLIBMM_DLL */
+
+#ifndef LIBXMLPP_VISIBILITY_DEFAULT
+  #define LIBXMLPP_VISIBILITY_DEFAULT
+#endif
+#ifndef LIBXMLPP_MEMBER_METHOD
+  #define LIBXMLPP_MEMBER_METHOD LIBXMLPP_API
+#endif
 
 #endif /* _LIBXMLPP_CONFIG_H */
 


### PR DESCRIPTION
Hi,

This attempts to make updates to `libxml++config.h.[in|meson]` so that we can accomodate exporting the whole `xmlpp::exception` class on MinGW builds but only export selectively on Visual Studio builds so that we can fix issue #45 (for MnGW) and also avoid having the built binaries from being ABI unstable by avoiding it being tied to a particular STL version.

With blessings, thank you!