### PR TITLE
headers: Drop LIBXMLPP_API from 'friend' members

### DIFF
--- a/libxml++/document.h
+++ b/libxml++/document.h
@@ -72,7 +72,7 @@ class Document : public NonCopyable
     ~Init() noexcept;
   };
 
-  friend LIBXMLPP_API class SaxParser;
+  friend class SaxParser;
 
 public:
   /** Create a new document.

--- a/libxml++/parsers/saxparser.h
+++ b/libxml++/parsers/saxparser.h
@@ -250,7 +250,7 @@ private:
   // and never seen in the API:
   std::unique_ptr<Document> entity_resolver_doc_;
 
-  friend LIBXMLPP_API struct SaxParserCallback;
+  friend struct SaxParserCallback;
 };
 
 } // namespace xmlpp

--- a/libxml++/parsers/textreader.h
+++ b/libxml++/parsers/textreader.h
@@ -292,7 +292,7 @@ class TextReader: public NonCopyable
 
   private:
     class PropertyReader;
-    friend LIBXMLPP_API class PropertyReader;
+    friend class PropertyReader;
 
     LIBXMLPP_API
     void setup_exceptions();


### PR DESCRIPTION
Hi,

This drops the `LIBXMLPP_API` from the `friend class` or `friend struct` members of classes, so that we can eliminate warnings on MinGW.  The other alternative is to handle these classes like what we did in MR #46, since class members are exported individually rather than exported as a whole, if we want to be very very sure about the ABI stability.

With blessings, thank you!