### PR TITLE
Use callback functions with C linkage

### DIFF
--- a/libxml++/parsers/parser.h
+++ b/libxml++/parsers/parser.h
@@ -19,6 +19,9 @@
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 extern "C" {
   struct _xmlParserCtxt;
+
+  /** @newin{5,2} */
+  using ParserCallbackCFuncType = void (*)(void* ctx, const char* msg, ...);
 }
 #endif //DOXYGEN_SHOULD_SKIP_THIS
 
@@ -199,15 +202,21 @@ protected:
   LIBXMLPP_API
   virtual void check_for_error_and_warning_messages();
 
+#ifndef LIBXMLXX_DISABLE_DEPRECATED
+  /** @deprecated Use get_callback_parser_error_cfunc() instead. */
   LIBXMLPP_API
   static void callback_parser_error(void* ctx, const char* msg, ...);
+  /** @deprecated Use get_callback_parser_warning_cfunc() instead. */
   LIBXMLPP_API
   static void callback_parser_warning(void* ctx, const char* msg, ...);
+  /** @deprecated Use get_callback_validity_error_cfunc() instead. */
   LIBXMLPP_API
   static void callback_validity_error(void* ctx, const char* msg, ...);
+  /** @deprecated Use get_callback_validity_warning_cfunc() instead. */
   LIBXMLPP_API
   static void callback_validity_warning(void* ctx, const char* msg, ...);
 
+  /** @deprecated */
   enum class MsgType
   {
     ParserError,
@@ -216,8 +225,28 @@ protected:
     ValidityWarning
   };
 
+  /** @deprecated Use the other callback_error_or_warning() overload instead. */
   LIBXMLPP_API
   static void callback_error_or_warning(MsgType msg_type, void* ctx,
+                                        const char* msg, va_list var_args);
+#endif // LIBXMLXX_DISABLE_DEPRECATED
+
+  /** @newin{5,2} */
+  LIBXMLPP_API
+  static ParserCallbackCFuncType get_callback_parser_error_cfunc();
+  /** @newin{5,2} */
+  LIBXMLPP_API
+  static ParserCallbackCFuncType get_callback_parser_warning_cfunc();
+  /** @newin{5,2} */
+  LIBXMLPP_API
+  static ParserCallbackCFuncType get_callback_validity_error_cfunc();
+  /** @newin{5,2} */
+  LIBXMLPP_API
+  static ParserCallbackCFuncType get_callback_validity_warning_cfunc();
+
+  /** @newin{5,2} */
+  LIBXMLPP_API
+  static void callback_error_or_warning(bool is_parser, bool is_error, void* ctx,
                                         const char* msg, va_list var_args);
 
   _xmlParserCtxt* context_;

--- a/libxml++/parsers/parser.h
+++ b/libxml++/parsers/parser.h
@@ -19,13 +19,17 @@
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 extern "C" {
   struct _xmlParserCtxt;
-
-  /** @newin{5,2} */
-  using ParserCallbackCFuncType = void (*)(void* ctx, const char* msg, ...);
 }
 #endif //DOXYGEN_SHOULD_SKIP_THIS
 
 namespace xmlpp {
+
+extern "C" {
+  /** Type of function pointer to callback function with C linkage.
+   * @newin{5,2}
+   */
+  using ParserCallbackCFuncType = void (*)(void* ctx, const char* msg, ...);
+}
 
 /** XML parser.
  *

--- a/libxml++/validators/dtdvalidator.cc
+++ b/libxml++/validators/dtdvalidator.cc
@@ -97,8 +97,8 @@ void DtdValidator::initialize_context()
   if (pimpl_->context)
   {
     //Tell the validation context about the callbacks:
-    pimpl_->context->error = &callback_validity_error;
-    pimpl_->context->warning = &callback_validity_warning;
+    pimpl_->context->error = get_callback_validity_error_cfunc();
+    pimpl_->context->warning = get_callback_validity_warning_cfunc();
 
     //Allow the callback_validity_*() methods to retrieve the C++ instance:
     pimpl_->context->userData = this;

--- a/libxml++/validators/relaxngvalidator.cc
+++ b/libxml++/validators/relaxngvalidator.cc
@@ -125,7 +125,8 @@ RelaxNGValidator::operator bool() const noexcept
 
 void RelaxNGValidator::initialize_context()
 {
-  xmlRelaxNGSetValidErrors(pimpl_->context, &callback_validity_error, &callback_validity_warning, this);
+  xmlRelaxNGSetValidErrors(pimpl_->context, get_callback_validity_error_cfunc(),
+                           get_callback_validity_warning_cfunc(), this);
   SchemaValidatorBase::initialize_context();
 }
 

--- a/libxml++/validators/validator.cc
+++ b/libxml++/validators/validator.cc
@@ -13,6 +13,33 @@
 #include <cstdarg> //For va_list.
 #include <memory> //For unique_ptr.
 
+namespace
+{
+// C++ linkage
+using ErrorOrWarningFuncType = void (*)(bool error, void* ctx,
+                                        const char* msg, va_list var_args);
+ErrorOrWarningFuncType p_callback_error_or_warning;
+
+extern "C"
+{
+static void c_callback_validity_error(void* ctx, const char* msg, ...)
+{
+  va_list var_args;
+  va_start(var_args, msg);
+  p_callback_error_or_warning(true, ctx, msg, var_args);
+  va_end(var_args);
+}
+
+static void c_callback_validity_warning(void* ctx, const char* msg, ...)
+{
+  va_list var_args;
+  va_start(var_args, msg);
+  p_callback_error_or_warning(false, ctx, msg, var_args);
+  va_end(var_args);
+}
+} // extern "C"
+} // anonymous namespace
+
 namespace xmlpp {
 
 Validator::Validator() noexcept
@@ -71,6 +98,7 @@ void Validator::check_for_validity_messages()
     exception_ = std::make_unique<validity_error>(msg);
 }
 
+#ifndef LIBXMLXX_DISABLE_DEPRECATED
 void Validator::callback_validity_error(void* valid_, const char* msg, ...)
 {
   auto validator = static_cast<Validator*>(valid_);
@@ -109,6 +137,48 @@ void Validator::callback_validity_warning(void* valid_, const char* msg, ...)
     try
     {
       validator->on_validity_warning(buff);
+    }
+    catch (...)
+    {
+      validator->handle_exception();
+    }
+  }
+}
+#endif // LIBXMLXX_DISABLE_DEPRECATED
+
+//static
+ValidatorCallbackCFuncType Validator::get_callback_validity_error_cfunc()
+{
+  p_callback_error_or_warning = &callback_error_or_warning;
+  return &c_callback_validity_error;
+}
+
+//static
+ValidatorCallbackCFuncType Validator::get_callback_validity_warning_cfunc()
+{
+  p_callback_error_or_warning = &callback_error_or_warning;
+  return &c_callback_validity_warning;
+}
+
+//static
+void Validator::callback_error_or_warning(bool error, void* ctx,
+                                          const char* msg, va_list var_args)
+{
+  // The caller of a libxml2 function with a callback is assumed to have
+  // specified that the validation context is a xmlpp::Validator instance.
+  auto validator = static_cast<Validator*>(ctx);
+
+  if (validator)
+  {
+    // Convert msg and var_args to a string:
+    const ustring buff = format_printf_message(msg, var_args);
+
+    try
+    {
+      if (error)
+        validator->on_validity_error(buff);
+      else
+        validator->on_validity_warning(buff);
     }
     catch (...)
     {

--- a/libxml++/validators/validator.h
+++ b/libxml++/validators/validator.h
@@ -17,12 +17,16 @@
 
 extern "C" {
   struct _xmlValidCtxt;
-
-  /** @newin{5,2} */
-  using ValidatorCallbackCFuncType = void (*)(void* ctx, const char* msg, ...);
 }
 
 namespace xmlpp {
+
+extern "C" {
+  /** Type of function pointer to callback function with C linkage.
+   * @newin{5,2}
+   */
+  using ValidatorCallbackCFuncType = void (*)(void* ctx, const char* msg, ...);
+}
 
 class Document;
 

--- a/libxml++/validators/validator.h
+++ b/libxml++/validators/validator.h
@@ -11,11 +11,15 @@
 #include <libxml++/noncopyable.h>
 #include <libxml++/exceptions/validity_error.h>
 #include <libxml++/exceptions/internal_error.h>
+#include <cstdarg> // va_list
 #include <memory> // std::unique_ptr
 #include <string>
 
 extern "C" {
   struct _xmlValidCtxt;
+
+  /** @newin{5,2} */
+  using ValidatorCallbackCFuncType = void (*)(void* ctx, const char* msg, ...);
 }
 
 namespace xmlpp {
@@ -81,10 +85,26 @@ protected:
   LIBXMLPP_API
   virtual void check_for_validity_messages();
 
+#ifndef LIBXMLXX_DISABLE_DEPRECATED
+  /** @deprecated Use get_callback_validity_error_cfunc() instead. */
   LIBXMLPP_API
   static void callback_validity_error(void* ctx, const char* msg, ...);
+  /** @deprecated Use get_callback_validity_warning_cfunc() instead. */
   LIBXMLPP_API
   static void callback_validity_warning(void* ctx, const char* msg, ...);
+#endif // LIBXMLXX_DISABLE_DEPRECATED
+
+  /** @newin{5,2} */
+  LIBXMLPP_API
+  static ValidatorCallbackCFuncType get_callback_validity_error_cfunc();
+  /** @newin{5,2} */
+  LIBXMLPP_API
+  static ValidatorCallbackCFuncType get_callback_validity_warning_cfunc();
+
+  /** @newin{5,2} */
+  LIBXMLPP_API
+  static void callback_error_or_warning(bool error, void* ctx,
+                                        const char* msg, va_list var_args);
 
   std::unique_ptr<exception> exception_;
   // Built gradually - used in an exception at the end of validation.

--- a/libxml++/validators/xsdvalidator.cc
+++ b/libxml++/validators/xsdvalidator.cc
@@ -122,7 +122,8 @@ XsdValidator::operator bool() const noexcept
 
 void XsdValidator::initialize_context()
 {
-  xmlSchemaSetValidErrors(pimpl_->context, &callback_validity_error, &callback_validity_warning, this);
+  xmlSchemaSetValidErrors(pimpl_->context, get_callback_validity_error_cfunc(),
+                          get_callback_validity_warning_cfunc(), this);
   SchemaValidatorBase::initialize_context();
 }
 


### PR DESCRIPTION
Code that mixes up C linkage and C++ linkage has undefined behavior.
Most compilers make no difference between C and C++ linkage, so it
has not been an issue so far. But see issue https://gitlab.gnome.org/GNOME/glibmm/-/issues/1

@fanc999 I have added new callback functions which are declared `extern "C"`.
It would be great if you could check if it works with MSVC. If anything must be
modified, you can add commits to the branch in this PR.

This job is a result of a glibmm issue, written 18 years ago. Most modules that
I work on contain illegal but so far harmless callback functions with C++ linkage.
The exception is libsigc++. It does not call C functions with callbacks.

I've already fixed cairomm. The fix there is much simpler than the one in this PR.
I intend to make fixes like these only in the modules' master branches.
