### PR TITLE
Meson: Cleanup and fix libxml2 dep search

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -100,92 +100,65 @@ install_pkgconfigdir = install_libdir / 'pkgconfig'
 # xmlxx_dep (created in libxml++/meson.build):
 #   Dependencies when using the libxml++ library.
 
-# libxml2's Windows-specific Makefiles don't create pkg-config files for us, so
-# we may need to look for it manually on Windows
 xml2_min_ver = '2.7.7'
 xml2_req = '>= @0@'.format(xml2_min_ver)
-xml2_dep = dependency('libxml-2.0', version: xml2_req, required: host_machine.system() != 'windows')
-xml2_is_subproject = false
+xml2_dep = dependency(
+  ['libxml-2.0', 'LibXml2'],
+  version: xml2_req,
+  required: host_machine.system() != 'windows'
+)
 
-libxml2_lib_set = false
+# Setup CMake subproject for use, if needed
 if not xml2_dep.found()
-  libxml2_lib = 'libxml2'
-  libxml2_lib_set = true
-  xml2_dep =  cpp_compiler.find_library(libxml2_lib,
-                                        has_headers: [
-                                          'libxml/globals.h',
-                                          'libxml/parser.h',
-                                          'libxml/parserInternals.h',
-                                          'libxml/relaxng.h',
-                                          'libxml/tree.h',
-                                          'libxml/xinclude.h',
-                                          'libxml/xpath.h',
-                                          'libxml/xpathInternals.h',
-                                          'libxml/xmlerror.h',
-                                          'libxml/xmlIO.h',
-                                          'libxml/xmlreader.h',
-                                          'libxml/xmlschemas.h',
-                                        ],
-                                       required: false)
-  if xml2_dep.found()
-    xml_min_ver_split = xml2_min_ver.split('.')
-    xml_min_ver_int = xml_min_ver_split[0].to_int() * 10000 + \
-                      xml_min_ver_split[1].to_int() * 100 + \
-                      xml_min_ver_split[2].to_int()
-
-    if not cpp_compiler.compiles('''#include <libxml/tree.h>
-                                 #if LIBXML_VERSION < @0@
-                                 # error libxml2 versions must be @1@ or later
-                                 #endif'''.format(xml_min_ver_int.to_string(), xml2_min_ver),
-                                 name : 'libxml2 is @0@ or later'.format(xml2_min_ver))
-      error('Your libxml2 installation must be @0@ or later'.format(xml2_min_ver))
-    endif
-  else
-    cmake = import('cmake')
-    opt_var = cmake.subproject_options()
-    build_shared = get_option('default_library') != 'static'
-    iconv_dep = dependency('iconv', required: false)
-    icu_i18n_dep = dependency('icu-i18n', required: false)
-    icu_uc_dep = dependency('icu-uc', required: false)
-    lzma_dep = dependency('liblzma', required: false)
-    thread_dep = dependency('threads', required: false)
-    zlib_dep = dependency('zlib', required: false)
-    winsock_dep = cpp_compiler.find_library('ws2_32', required: false)
-    cmake_build_type = get_option('buildtype')
-    if get_option('buildtype') == 'debugoptimized'
-      cmake_build_type = 'RelWithDebInfo'
-    elif get_option('buildtype') == 'minsize'
-      cmake_build_type = 'MinSizeRel'
-    elif get_option('buildtype') == 'plain'
-      cmake_build_type = ''
-    endif
-    opt_var.add_cmake_defines({'BUILD_SHARED_LIBS': build_shared,
-                               'CMAKE_BUILD_TYPE': cmake_build_type,
-                               'CMAKE_MSVC_RUNTIME_LIBRARY': '',
-                               'CMAKE_C_FLAGS_INIT': '',
-                               'CMAKE_C_FLAGS_DEBUG': '',
-                               'CMAKE_C_FLAGS_RELEASE': '',
-                               'CMAKE_C_FLAGS_RELWITHDEBINFO': '',
-                               'CMAKE_C_FLAGS_MINSIZEREL': '',
-                               'LIBXML2_WITH_HTTP': host_machine.system() != 'windows' or winsock_dep.found(),
-                               'LIBXML2_WITH_ICONV': iconv_dep.found(),
-                               'LIBXML2_WITH_ICU': icu_i18n_dep.found() and icu_uc_dep.found(),
-                               'LIBXML2_WITH_LZMA': lzma_dep.found(),
-                               'LIBXML2_WITH_PYTHON': false,
-                               'LIBXML2_WITH_TESTS': build_tests,
-                               'LIBXML2_WITH_THREADS': thread_dep.found(),
-                               'LIBXML2_WITH_ZLIB': zlib_dep.found(),
-                              })
-
-    xml2_sp = cmake.subproject('libxml2_cmake', options: opt_var)
-    xml2_dep = xml2_sp.dependency('LibXml2')
-    xml2_is_subproject = true
-
-    if build_tests
-      test('testchar', xml2_sp.target('testchar'))
-      test('testdict', xml2_sp.target('testdict'))
-    endif
+  cmake = import('cmake')
+  opt_var = cmake.subproject_options()
+  build_shared = get_option('default_library') != 'static'
+  iconv_dep = dependency('iconv', required: false)
+  icu_i18n_dep = dependency('icu-i18n', 'ICU',
+                              components: 'in',
+                            required: false)
+  icu_uc_dep = dependency('icu-uc',  'ICU',
+                            components: 'uc',
+                          required: false)
+  lzma_dep = dependency(['liblzma','LibLZMA'], required: false)
+  thread_dep = dependency('threads', required: false)
+  zlib_dep = dependency('zlib', required: false)
+  winsock_dep = cpp_compiler.find_library('ws2_32', required: false)
+  cmake_build_type = get_option('buildtype')
+  if get_option('buildtype') == 'debugoptimized'
+    cmake_build_type = 'RelWithDebInfo'
+  elif get_option('buildtype') == 'minsize'
+    cmake_build_type = 'MinSizeRel'
+  elif get_option('buildtype') == 'plain'
+    cmake_build_type = ''
   endif
+  opt_var.add_cmake_defines({
+    'BUILD_SHARED_LIBS': build_shared,
+    'CMAKE_BUILD_TYPE': cmake_build_type,
+    'CMAKE_MSVC_RUNTIME_LIBRARY': '',
+    'CMAKE_C_FLAGS_INIT': '',
+    'CMAKE_C_FLAGS_DEBUG': '',
+    'CMAKE_C_FLAGS_RELEASE': '',
+    'CMAKE_C_FLAGS_RELWITHDEBINFO': '',
+    'CMAKE_C_FLAGS_MINSIZEREL': '',
+    'LIBXML2_WITH_HTTP': host_machine.system() != 'windows' or winsock_dep.found(),
+    'LIBXML2_WITH_ICONV': iconv_dep.found(),
+    'LIBXML2_WITH_ICU': icu_i18n_dep.found() and icu_uc_dep.found(),
+    'LIBXML2_WITH_LZMA': lzma_dep.found(),
+    'LIBXML2_WITH_PYTHON': false,
+    'LIBXML2_WITH_TESTS': build_tests,
+    'LIBXML2_WITH_THREADS': thread_dep.found(),
+    'LIBXML2_WITH_ZLIB': zlib_dep.found(),
+  })
+  xml2_sp = cmake.subproject('libxml2_cmake', options: opt_var)
+  xml2_dep = xml2_sp.dependency('LibXml2')
+endif
+
+xml2_is_subproject = xml2_dep.type_name() == 'internal'
+
+if xml2_is_subproject and build_tests
+  test('testchar', xml2_sp.target('testchar'))
+  test('testdict', xml2_sp.target('testdict'))
 endif
 
 xmlxx_requires = []
@@ -196,9 +169,10 @@ libxml2_lib_pkgconfig = ''
 if xml2_dep.type_name() == 'pkgconfig'
   xmlxx_requires += ['libxml-2.0', xml2_req]
 else
-  if libxml2_lib_set
-    libxml2_lib_pkgconfig = '-l@0@'.format(libxml2_lib)
-  endif
+  libxml2_lib_pkgconfig = xml2_dep.get_variable(
+    cmake:         'LIBXML2_LIBRARIES',
+    default_value: 'LibXml2.lib',
+  )
 endif
 
 xmlxx_requires = ' '.join(xmlxx_requires)


### PR DESCRIPTION
Hi,

This attempts to clean up the Visual Studio parts of the Meson build files by letting CMake help finding libxml2 (which does a more comprehensive version of using `%INCLUDE%` and `%LIB%` so that we don't have to reinvent wheels), and consolidate the libxml2 search in a single `dependency()` call as this is supported since Meson 0.60.0 and later.

Also update the libxml2 CMake subproject by using CMake to find ICU and liblzma in the same manner, and work a bit harder to ensure that we have the correct libxml2 .lib in the resulting pkg-config file for libxml++, by using CMake's info where applicable, before falling back to the plain `LibXml2.lib`.

With blessings, thank you!