### PR TITLE
meson: Backport libxml2 CMake support (for libxml++-4-0)

### DIFF
--- a/libxml++/meson.build
+++ b/libxml++/meson.build
@@ -1,7 +1,8 @@
 # libxml++
 
 # Input: xmlxx_build_dep, xmlxx_pcname, xmlxx_libversion, xmlxx_api_version,
-#        install_includedir, xmlxx_rc, xmlxx_libname, macos_darwin_versions
+#        install_includedir, xmlxx_rc, xmlxx_libname, macos_darwin_versions,
+#        xml2_is_subproject
 # Output: source_h_files, xmlxx_own_dep
 
 # There are no built source files in libxml++-4.0.
@@ -98,6 +99,10 @@ if host_machine.system() == 'windows'
   windows = import('windows')
   xmlxx_res = windows.compile_resources(xmlxx_rc)
   extra_xmlxx_objects += xmlxx_res
+endif
+
+if xml2_is_subproject
+  xmlxx_build_dep += winsock_dep
 endif
 
 extra_include_dirs = ['..']

--- a/meson.build
+++ b/meson.build
@@ -107,42 +107,81 @@ install_pkgconfigdir = install_libdir / 'pkgconfig'
 glibmm_req = '>= 2.68.0'
 glibmm_req_minor_ver = '68'
 
-# libxml2's Windows-specific Makefiles don't create pkg-config files for us, so
-# we may need to look for it manually on Windows
 xml2_min_ver = '2.7.7'
 xml2_req = '>= @0@'.format(xml2_min_ver)
-xml2_dep = dependency('libxml-2.0', version: xml2_req, required: host_machine.system() != 'windows')
+
+# Sadly, this is not Meson 0.60.x or later...
+xml2_dep = dependency(
+  'libxml-2.0',
+  version: xml2_req,
+  required: host_machine.system() != 'windows'
+)
 
 if not xml2_dep.found()
-  libxml2_lib = 'libxml2'
-  xml2_dep =  cpp_compiler.find_library(libxml2_lib,
-                                        has_headers: [
-                                          'libxml/globals.h',
-                                          'libxml/parser.h',
-                                          'libxml/parserInternals.h',
-                                          'libxml/relaxng.h',
-                                          'libxml/tree.h',
-                                          'libxml/xinclude.h',
-                                          'libxml/xpath.h',
-                                          'libxml/xpathInternals.h',
-                                          'libxml/xmlerror.h',
-                                          'libxml/xmlIO.h',
-                                          'libxml/xmlreader.h',
-                                          'libxml/xmlschemas.h',
-                                        ])
+  xml2_dep = dependency(
+    'LibXml2',
+    version: xml2_req,
+    required: host_machine.system() != 'windows'
+  )
+endif
 
-    xml_min_ver_split = xml2_min_ver.split('.')
-    xml_min_ver_int = xml_min_ver_split[0].to_int() * 10000 + \
-                      xml_min_ver_split[1].to_int() * 100 + \
-                      xml_min_ver_split[2].to_int()
+# Setup CMake subproject for use, if needed
+if not xml2_dep.found()
+  cmake = import('cmake')
+  opt_var = cmake.subproject_options()
+  build_shared = get_option('default_library') != 'static'
+  iconv_dep = dependency('iconv', required: false)
+  icu_i18n_dep = dependency('icu-i18n', required: false)
+  if not icu_i18n_dep.found()
+    icu_i18n_dep = dependency('ICU',
+                              components: 'in',
+                              required: false)
+  endif
+  icu_uc_dep = dependency('icu-uc', required: false)
+  if not icu_uc_dep.found()
+    icu_uc_dep = dependency('ICU',
+                            components: 'uc',
+                            required: false)
+  endif
+  lzma_dep = dependency('liblzma', required: false)
+  thread_dep = dependency('threads', required: false)
+  zlib_dep = dependency('zlib', required: false)
+  winsock_dep = cpp_compiler.find_library('ws2_32', required: false)
+  cmake_build_type = get_option('buildtype')
+  if get_option('buildtype') == 'debugoptimized'
+    cmake_build_type = 'RelWithDebInfo'
+  elif get_option('buildtype') == 'minsize'
+    cmake_build_type = 'MinSizeRel'
+  elif get_option('buildtype') == 'plain'
+    cmake_build_type = ''
+  endif
+  opt_var.add_cmake_defines({
+    'BUILD_SHARED_LIBS': build_shared,
+    'CMAKE_BUILD_TYPE': cmake_build_type,
+    'CMAKE_MSVC_RUNTIME_LIBRARY': '',
+    'CMAKE_C_FLAGS_INIT': '',
+    'CMAKE_C_FLAGS_DEBUG': '',
+    'CMAKE_C_FLAGS_RELEASE': '',
+    'CMAKE_C_FLAGS_RELWITHDEBINFO': '',
+    'CMAKE_C_FLAGS_MINSIZEREL': '',
+    'LIBXML2_WITH_HTTP': host_machine.system() != 'windows' or winsock_dep.found(),
+    'LIBXML2_WITH_ICONV': iconv_dep.found(),
+    'LIBXML2_WITH_ICU': icu_i18n_dep.found() and icu_uc_dep.found(),
+    'LIBXML2_WITH_LZMA': lzma_dep.found(),
+    'LIBXML2_WITH_PYTHON': false,
+    'LIBXML2_WITH_TESTS': build_tests,
+    'LIBXML2_WITH_THREADS': thread_dep.found(),
+    'LIBXML2_WITH_ZLIB': zlib_dep.found(),
+  })
+  xml2_sp = cmake.subproject('libxml2_cmake', options: opt_var)
+  xml2_dep = xml2_sp.dependency('LibXml2')
+endif
 
-    if not cpp_compiler.compiles('''#include <libxml/tree.h>
-                                    #if LIBXML_VERSION < @0@
-                                    # error libxml2 versions must be @1@ or later
-                                    #endif'''.format(xml_min_ver_int.to_string(), xml2_min_ver),
-                                    name : 'libxml2 is @0@ or later'.format(xml2_min_ver))
-      error('Your libxml2 installation must be @0@ or later'.format(xml2_min_ver))
-    endif
+xml2_is_subproject = xml2_dep.type_name() == 'internal'
+
+if xml2_is_subproject and build_tests
+  test('testchar', xml2_sp.target('testchar'))
+  test('testdict', xml2_sp.target('testdict'))
 endif
 
 glibmm_dep = dependency('glibmm-2.@0@'.format(glibmm_req_minor_ver), version: glibmm_req)
@@ -155,7 +194,10 @@ libxml2_lib_pkgconfig = ''
 if xml2_dep.type_name() == 'pkgconfig'
   xmlxx_requires += ['libxml-2.0', xml2_req]
 else
-  libxml2_lib_pkgconfig = '-l@0@'.format(libxml2_lib)
+  libxml2_lib_pkgconfig = xml2_dep.get_variable(
+    cmake:         'LIBXML2_LIBRARIES',
+    default_value: 'LibXml2.lib',
+  )
 endif
 
 # ...Then put glibmm-2.x in the 'Requires:' section in the generated pkg-config file


### PR DESCRIPTION
Hi,

This MR attempts to backport CMake support for finding/building libxml2, from the master/`libxml++-5-0` branches, where:

*  We supersede searching for libxml2 manually on Windows by using CMake, which actually does the original manual search in a more comprehensive way on Windows, so we don't need to reinvent wheels here.
* We also add support for Windows to build libxml2 as a subproject using CMake.
* Since we are using Meson 0.55.x or later, we needed to call `dependency(...)` two times for dependencies that have different naming schemes, such as libxml2 and ICU.

With blessings, thank you!