### PR TITLE
remove invalid FSF licenses from license text and in-file attributions

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -2,7 +2,7 @@
 		       Version 2.1, February 1999
 
  Copyright (C) 1991, 1999 Free Software Foundation, Inc.
-     59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -484,8 +484,7 @@ convey the exclusion of warranty; and each file should have at least the
     Lesser General Public License for more details.
 
     You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    License along with this library; if not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 

--- a/examples/dom_build/main.cc
+++ b/examples/dom_build/main.cc
@@ -13,8 +13,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <cstdlib>

--- a/examples/dom_parse_entities/main.cc
+++ b/examples/dom_parse_entities/main.cc
@@ -13,8 +13,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <libxml++/libxml++.h>

--- a/examples/dom_parser/main.cc
+++ b/examples/dom_parser/main.cc
@@ -13,8 +13,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <libxml++/libxml++.h>

--- a/examples/dom_parser_raw/main.cc
+++ b/examples/dom_parser_raw/main.cc
@@ -13,8 +13,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <libxml++/libxml++.h>

--- a/examples/dom_read_write/main.cc
+++ b/examples/dom_read_write/main.cc
@@ -15,8 +15,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifdef HAVE_CONFIG_H

--- a/examples/dom_xpath/main.cc
+++ b/examples/dom_xpath/main.cc
@@ -13,8 +13,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <cstdlib>

--- a/examples/dtdvalidation/main.cc
+++ b/examples/dtdvalidation/main.cc
@@ -13,8 +13,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 

--- a/examples/sax_exception/main.cc
+++ b/examples/sax_exception/main.cc
@@ -13,8 +13,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 /* This example is nearly the same than sax_parser, but demonstrate how exception

--- a/examples/sax_exception/myparser.cc
+++ b/examples/sax_exception/myparser.cc
@@ -13,8 +13,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "myparser.h"

--- a/examples/sax_exception/myparser.h
+++ b/examples/sax_exception/myparser.h
@@ -13,8 +13,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef __LIBXMLPP_EXAMPLES_MYPARSER_H

--- a/examples/sax_parser/main.cc
+++ b/examples/sax_parser/main.cc
@@ -13,8 +13,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifdef HAVE_CONFIG_H

--- a/examples/sax_parser/myparser.cc
+++ b/examples/sax_parser/myparser.cc
@@ -15,8 +15,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "myparser.h"

--- a/examples/sax_parser/myparser.h
+++ b/examples/sax_parser/myparser.h
@@ -15,8 +15,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef __LIBXMLPP_EXAMPLES_MYPARSER_H

--- a/examples/sax_parser_build_dom/main.cc
+++ b/examples/sax_parser_build_dom/main.cc
@@ -15,8 +15,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <cstdlib>

--- a/examples/sax_parser_build_dom/svgdocument.cc
+++ b/examples/sax_parser_build_dom/svgdocument.cc
@@ -15,8 +15,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "svgdocument.h"

--- a/examples/sax_parser_build_dom/svgdocument.h
+++ b/examples/sax_parser_build_dom/svgdocument.h
@@ -15,8 +15,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef __LIBXMLPP_SVGDOCUMENT_H

--- a/examples/sax_parser_build_dom/svgelement.cc
+++ b/examples/sax_parser_build_dom/svgelement.cc
@@ -15,8 +15,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "svgelement.h"

--- a/examples/sax_parser_build_dom/svgelement.h
+++ b/examples/sax_parser_build_dom/svgelement.h
@@ -15,8 +15,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef __LIBXMLPP_SVGELEMENT_H

--- a/examples/sax_parser_build_dom/svggroup.h
+++ b/examples/sax_parser_build_dom/svggroup.h
@@ -15,8 +15,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef __LIBXMLPP_SVGGROUP_H

--- a/examples/sax_parser_build_dom/svgparser.cc
+++ b/examples/sax_parser_build_dom/svgparser.cc
@@ -15,8 +15,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <iostream>

--- a/examples/sax_parser_build_dom/svgparser.h
+++ b/examples/sax_parser_build_dom/svgparser.h
@@ -15,8 +15,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef __LIBXMLPP_SVGPARSER_H

--- a/examples/sax_parser_build_dom/svgpath.h
+++ b/examples/sax_parser_build_dom/svgpath.h
@@ -15,8 +15,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef __LIBXMLPP_SVGPATH_H

--- a/examples/sax_parser_entities/main.cc
+++ b/examples/sax_parser_entities/main.cc
@@ -13,8 +13,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifdef HAVE_CONFIG_H

--- a/examples/sax_parser_entities/myparser.cc
+++ b/examples/sax_parser_entities/myparser.cc
@@ -13,8 +13,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "myparser.h"

--- a/examples/sax_parser_entities/myparser.h
+++ b/examples/sax_parser_entities/myparser.h
@@ -13,8 +13,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef __LIBXMLPP_EXAMPLES_MYPARSER_H

--- a/examples/schemavalidation/main.cc
+++ b/examples/schemavalidation/main.cc
@@ -13,8 +13,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifdef HAVE_CONFIG_H

--- a/examples/textreader/main.cc
+++ b/examples/textreader/main.cc
@@ -13,8 +13,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <libxml++/libxml++.h>

--- a/libxml++/exceptions/exception.h
+++ b/libxml++/exceptions/exception.h
@@ -13,8 +13,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef __LIBXMLPP_EXCEPTION_H

--- a/libxml++/exceptions/internal_error.h
+++ b/libxml++/exceptions/internal_error.h
@@ -13,8 +13,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef __LIBXMLPP_INTERNAL_ERROR_H

--- a/libxml++/exceptions/parse_error.h
+++ b/libxml++/exceptions/parse_error.h
@@ -13,8 +13,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef __LIBXMLPP_PARSE_ERROR_H

--- a/libxml++/exceptions/validity_error.h
+++ b/libxml++/exceptions/validity_error.h
@@ -13,8 +13,7 @@
  * Library General Public License for more details.
  *
  * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the Free
- * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef __LIBXMLPP_VALIDITY_ERROR_H

--- a/libxml++/exceptions/wrapped_exception.cc
+++ b/libxml++/exceptions/wrapped_exception.cc
@@ -11,8 +11,7 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "wrapped_exception.h"

--- a/libxml++/exceptions/wrapped_exception.h
+++ b/libxml++/exceptions/wrapped_exception.h
@@ -11,8 +11,7 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef __LIBXMLPP_WRAPPED_EXCEPTION_H

--- a/libxml++/ustring.h
+++ b/libxml++/ustring.h
@@ -12,8 +12,7 @@
  *  Lesser General Public License for more details.
  *
  *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *  License along with this library; if not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -11,8 +11,7 @@
 ## Lesser General Public License for more details.
 ##
 ## You should have received a copy of the GNU Lesser General Public
-## License along with this library; if not, write to the Free Software
-## Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+## License along with this library; if not, see <https://www.gnu.org/licenses/>.
 
 AM_CPPFLAGS = -I$(top_builddir) -I$(top_srcdir) -I. $(LIBXMLXX_CFLAGS)
 AM_CXXFLAGS = $(LIBXMLXX_WXXFLAGS)

--- a/tests/istream_ioparser/main.cc
+++ b/tests/istream_ioparser/main.cc
@@ -11,8 +11,7 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <libxml++/libxml++.h>

--- a/tests/saxparser_chunk_parsing_inconsistent_state/main.cc
+++ b/tests/saxparser_chunk_parsing_inconsistent_state/main.cc
@@ -11,8 +11,7 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <libxml++/libxml++.h>

--- a/tests/saxparser_parse_double_free/main.cc
+++ b/tests/saxparser_parse_double_free/main.cc
@@ -11,8 +11,7 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <libxml++/libxml++.h>

--- a/tests/saxparser_parse_stream_inconsistent_state/main.cc
+++ b/tests/saxparser_parse_stream_inconsistent_state/main.cc
@@ -11,8 +11,7 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <libxml++/libxml++.h>


### PR DESCRIPTION
The Free Software Foundation no longer has a physical office (either at Temple Place or Mass Ave) and has adjusted their license texts to point people to their website instead of a mailing address. See: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt

This change updates the COPYING file and all of the incorrect in-file attributions.