### PR TITLE
TextReader: fix naming clash with libxml macro

### DIFF
--- a/libxml++/parsers/textreader.cc
+++ b/libxml++/parsers/textreader.cc
@@ -61,7 +61,7 @@ public:
   int Int(int value);
   bool Bool(int value);
   char Char(int value);
-  ustring String(xmlChar* value, bool free = false);
+  ustring String(xmlChar* value, bool should_free = false);
   ustring String(xmlChar const* value);
   std::optional<ustring> OptString(xmlChar* value);
 
@@ -531,7 +531,7 @@ char TextReader::PropertyReader::Char(int value)
   return value;
 }
 
-ustring TextReader::PropertyReader::String(xmlChar* value, bool free)
+ustring TextReader::PropertyReader::String(xmlChar* value, bool should_free)
 {
   owner_.check_for_exceptions();
 
@@ -540,7 +540,7 @@ ustring TextReader::PropertyReader::String(xmlChar* value, bool free)
 
   ustring result = (char *)value;
 
-  if(free)
+  if(should_free)
     xmlFree(value);
 
   return result;


### PR DESCRIPTION
In the macOS 26 SDK, xmlFree is defined as a macro for free. This causes issues where a same-named variable is used. Renaming the variable to should_free resolves the issue.

See:

    $ grep -B4 -A2 -n "#define xmlFree(" "Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.sdk/usr/include/libxml/globals.h"
    261-#if defined(LIBXML_HAS_DEPRECATED_MEMORY_ALLOCATION_FUNCTIONS)
    262-#define xmlMalloc(size) malloc(size)
    263-#define xmlMallocAtomic(size) malloc(size)
    264-#define xmlRealloc(ptr, size) realloc((ptr), (size))
    265:#define xmlFree(ptr) free(ptr)
    266-#define xmlMemStrdup(str) strdup(str)
    267-#endif

Fixes:

    FAILED: [code=1] libxml++/libxml++-2.6.2.dylib.p/parsers_textreader.cc.o
    clang++ -Ilibxml++/libxml++-2.6.2.dylib.p -I. -I.. -I/opt/homebrew/Cellar/glibmm@2.66/2.66.8/include/glibmm-2.4 -I/opt/homebrew/Cellar/glibmm@2.66/2.66.8/lib/glibmm-2.4/include -I/opt/homebrew/Cellar/glib/2.86.0/include -I/opt/homebrew/Cellar/glib/2.86.0/include/glib-2.0 -I/opt/homebrew/Cellar/glib/2.86.0/lib/glib-2.0/include -I/opt/homebrew/opt/gettext/include -I/opt/homebrew/Cellar/pcre2/10.46/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/usr/include/ffi -I/opt/homebrew/Cellar/libsigc++@2/2.10.8/include/sigc++-2.0 -I/opt/homebrew/Cellar/libsigc++@2/2.10.8/lib/sigc++-2.0/include -fdiagnostics-color=always -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST -Wall -Winvalid-pch -std=c++11 -O3 -DLIBXMLPP_BUILD=1 -MD -MQ libxml++/libxml++-2.6.2.dylib.p/parsers_textreader.cc.o -MF libxml++/libxml++-2.6.2.dylib.p/parsers_textreader.cc.o.d -o libxml++/libxml++-2.6.2.dylib.p/parsers_textreader.cc.o -c ../libxml++/parsers/textreader.cc
    ../libxml++/parsers/textreader.cc:416:5: error: called object type 'bool' is not a function or function pointer
      416 |     xmlFree(value);
          |     ^~~~~~~~~~~~~~
    /Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk/usr/include/libxml/globals.h:265:26: note: expanded from macro 'xmlFree'
      265 | #define xmlFree(ptr) free(ptr)
          |                      ~~~~^
    1 error generated.
