### PR TITLE
Support Visual Studio 2026 builds and make NMake Makefiles more flexible and robust (for master/5.x)

### DIFF
--- a/MSVC_NMake/MSVC-Builds.md
+++ b/MSVC_NMake/MSVC-Builds.md
@@ -34,10 +34,12 @@ rebuilding items using libxml++ is inconvenient):
     * 2017: `VSVER=15`, `xml++-vc141-5_0.[dll|pdb|lib]`
     * 2019: `VSVER=16`, `xml++-vc142-5_0.[dll|pdb|lib]`
     * 2022: `VSVER=17`, `xml++-vc143-5_0.[dll|pdb|lib]`
+    * 2026: `VSVER=18`, `xml++-vc145-5_0.[dll|pdb|lib]`
   * Meson:
     * 2017: `VSVER=15`, `xml++-vc141-5.0-1[dll|pdb]`, `xml++-vc141-5.0.lib`
     * 2019: `VSVER=16`, `xml++-vc142-5.0-1[dll|pdb]`, `xml++-vc142-5.0.lib`
     * 2022: `VSVER=17`, `xml++-vc143-5.0-1[dll|pdb]`, `xml++-vc143-5.0.lib`
+    * 2026: `VSVER=18`, `xml++-vc145-5.0-1[dll|pdb]`, `xml++-vc143-5.0.lib`
 
 
 ### NMake Builds

--- a/MSVC_NMake/MSVC-Builds.md
+++ b/MSVC_NMake/MSVC-Builds.md
@@ -6,21 +6,23 @@ required and only 15.7.x or later had adequate `C++-17` support.
 * Install libxml2 from https://xmlsoft.org/, either via Windows binaries or
 building from source, using NMake or CMake.  It is strongly recommended, if
 building libxml2 from source, that Visual Studio 2015 or later is used.
-* Add libxml2's include path to `%INCLUDE%` and its library path to `%LIB%`, or
-placing the dependencies like the following:
+* For locating libxml2, do one of the following:
+  * Add libxml2's include path to `%INCLUDE%` and its library path to `%LIB%`, for NMake
+  or Meson
+  * See the following NMake and Meson sections for finding the libxml2 and dependent libraries.
+  * Or, Place the libxml2 installation like the following, and pass in `PREFIX=$(prefix)` for NMake:
 ```
-$(some_dir_1)\include
+$(prefix)\include
    |
    --libxml2\libxml\*.h
-   |
-   --(headers of libraries libxml2 depends on, such as ZLib, liblzma...)
 
-$(some_dir_2)\lib
+$(prefix)\lib
    |
    --libxml2.lib
    |
-   --(.lib's of libraries that libxml2 depends on, such as ZLib, liblzma)
+   --(.lib's of libraries that libxml2 depends on, such as ZLib, liblzma, if libxml2 is a static build)
 ```
+
 * You need libxml2's DLL and all of its dependent DLLs in `%PATH%` if linking
 against a DLL build of libxml2 in order to run the tests.
 
@@ -54,11 +56,15 @@ rebuilding items using libxml++ is inconvenient):
 cd $(srcroot)\MSVC_NMake
 # Run "nmake /f Makefile.vc" to see to see what options are supported by
 # the NMake Makefiles
-# INCLUDEDIR is by default $(PREFIX)\include, and LIBDIR is by default
+# BASE_INCLUDEDIR is by default $(PREFIX)\include, and BASE_LIBDIR is by default
 # $(PREFIX)\lib. PREFIX is by default $(srcroot)\..\vs$(VSVER\$(Platform).
 # $(some_dir_1) and $(some_dir_2) refer to the sample layout listed above.
+# LIBXML2_INCLUDEDIR is by default $(BASE_INCLUDEDIR); the libxml2 headers will
+# be searched for in $(LIBXML2_INCLUDEDIR)\libxml2.
+# LIBXML2_LIBDIR is by default $(BASE_LIBDIR); if libxml2 is a static build its
+# dependent libraries should be placed in $(BASE_LIBDIR)
 
-nmake /f Makefile.vc CFG=[debug|release] [PREFIX=...] [INCLUDEDIR=$(some_dir_1)\include] [LIBDIR=$(some_dir_2)\lib]
+nmake /f Makefile.vc CFG=[debug|release] [other_options]
 ```
 * The following targets are supported (only DLL builds are supported out of the
 box with the NMake Makefiles):
@@ -73,7 +79,9 @@ For Visual Studio builds, it is also recommended that CMake is installed and can
 be found in `%PATH%`, so that it can help with finding an installed libxml2, or
 build libxml2 alongside with libxml++ if it is not previously installed. If
 libxml2 is installed, you will most probably need to add its include directory
-to `%INCLUDE%` and its library path to `%LIB%`, as described earlier.
+to `%INCLUDE%` and its library path to `%LIB%`, as described earlier, or use
+`--cmake-prefix-path` to point to libxml2's installation directory or
+`--pkg-config-path` to point to where your libxml2's pkg-config files can be found.
 
 
 Cedric Gustin

--- a/MSVC_NMake/build-rules-msvc.mak
+++ b/MSVC_NMake/build-rules-msvc.mak
@@ -14,43 +14,43 @@
 # $<
 # <<
 
-{..\libxml++\}.cc{vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\}.obj::
-	@if not exist vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\ md vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx
-	$(CXX) $(LIBXMLXX_CFLAGS) $(CFLAGS_NOGL) /Fovs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\ /Fdvs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\ /c @<<
+{..\libxml++\}.cc{$(OUTDIR)\libxmlxx\}.obj::
+	@if not exist $(OUTDIR)\libxmlxx\ md $(OUTDIR)\libxmlxx
+	$(CXX) $(CFLAGS) $(LIBXMLXX_CFLAGS) $(LIBXMLXX_INCLUDES) /Fo$(OUTDIR)\libxmlxx\ /Fd$(OUTDIR)\libxmlxx\ /c @<<
 $<
 <<
 
-{..\libxml++\exceptions\}.cc{vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\}.obj::
-	@if not exist vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\ md vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx
-	$(CXX) $(LIBXMLXX_CFLAGS) $(CFLAGS_NOGL) /Fovs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\ /Fdvs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\ /c @<<
+{..\libxml++\exceptions\}.cc{$(OUTDIR)\libxmlxx\}.obj::
+	@if not exist $(OUTDIR)\libxmlxx\ md $(OUTDIR)\libxmlxx
+	$(CXX) $(CFLAGS) $(LIBXMLXX_CFLAGS) $(LIBXMLXX_INCLUDES) /Fo$(OUTDIR)\libxmlxx\ /Fd$(OUTDIR)\libxmlxx\ /c @<<
 $<
 <<
 
-{..\libxml++\io\}.cc{vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\}.obj::
-	@if not exist vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\ md vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx
-	$(CXX) $(LIBXMLXX_CFLAGS) $(CFLAGS_NOGL) /Fovs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\ /Fdvs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\ /c @<<
+{..\libxml++\io\}.cc{$(OUTDIR)\libxmlxx\}.obj::
+	@if not exist $(OUTDIR)\libxmlxx\ md $(OUTDIR)\libxmlxx
+	$(CXX) $(CFLAGS) $(LIBXMLXX_CFLAGS) $(LIBXMLXX_INCLUDES) /Fo$(OUTDIR)\libxmlxx\ /Fd$(OUTDIR)\libxmlxx\ /c @<<
 $<
 <<
 
-{..\libxml++\nodes\}.cc{vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\}.obj::
-	@if not exist vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\ md vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx
-	$(CXX) $(LIBXMLXX_CFLAGS) $(CFLAGS_NOGL) /Fovs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\ /Fdvs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\ /c @<<
+{..\libxml++\nodes\}.cc{$(OUTDIR)\libxmlxx\}.obj::
+	@if not exist $(OUTDIR)\libxmlxx\ md $(OUTDIR)\libxmlxx
+	$(CXX) $(CFLAGS) $(LIBXMLXX_CFLAGS) $(LIBXMLXX_INCLUDES) /Fo$(OUTDIR)\libxmlxx\ /Fd$(OUTDIR)\libxmlxx\ /c @<<
 $<
 <<
 
-{..\libxml++\parsers\}.cc{vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\}.obj::
-	@if not exist vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\ md vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx
-	$(CXX) $(LIBXMLXX_CFLAGS) $(CFLAGS_NOGL) /Fovs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\ /Fdvs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\ /c @<<
+{..\libxml++\parsers\}.cc{$(OUTDIR)\libxmlxx\}.obj::
+	@if not exist $(OUTDIR)\libxmlxx\ md $(OUTDIR)\libxmlxx
+	$(CXX) $(CFLAGS) $(LIBXMLXX_CFLAGS) $(LIBXMLXX_INCLUDES) /Fo$(OUTDIR)\libxmlxx\ /Fd$(OUTDIR)\libxmlxx\ /c @<<
 $<
 <<
 
-{..\libxml++\validators\}.cc{vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\}.obj::
-	@if not exist vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\ md vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx
-	$(CXX) $(LIBXMLXX_CFLAGS) $(CFLAGS_NOGL) /Fovs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\ /Fdvs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\ /c @<<
+{..\libxml++\validators\}.cc{$(OUTDIR)\libxmlxx\}.obj::
+	@if not exist $(OUTDIR)\libxmlxx\ md $(OUTDIR)\libxmlxx
+	$(CXX) $(CFLAGS) $(LIBXMLXX_CFLAGS) $(LIBXMLXX_INCLUDES) /Fo$(OUTDIR)\libxmlxx\ /Fd$(OUTDIR)\libxmlxx\ /c @<<
 $<
 <<
 
-{.\libxml++\}.rc{vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\}.res:
+{.\libxml++\}.rc{$(OUTDIR)\libxmlxx\}.res:
 	@if not exist $(@D)\ md $(@D)
 	rc /fo$@ $<
 
@@ -65,7 +65,7 @@ $(LIBXMLXX_LIB): $(LIBXMLXX_DLL)
 # <<
 # 	@-if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;2
 $(LIBXMLXX_DLL): $(libxmlxx_OBJS)
-	link /DLL $(LDFLAGS_NOLTCG) $(LIBXML2_LIBS) /implib:$(LIBXMLXX_LIB) -out:$@ @<<
+	link /DLL $(LDFLAGS) $(DEP_LDFLAGS) /implib:$(LIBXMLXX_LIB) -out:$@ @<<
 $(libxmlxx_OBJS)
 <<
 	@-if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;2
@@ -79,19 +79,19 @@ $(libxmlxx_OBJS)
 # 	@-if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;1
 
 clean:
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.exe
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.dll
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.pdb
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.ilk
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.exp
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.lib
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx-tests\*.obj
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx-tests\*.pdb
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx-examples\*.obj
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx-examples\*.pdb
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\*.res
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\*.obj
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx\*.pdb
-	@-rd vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx-tests
-	@-rd vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx-examples
-	@-rd vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx
+	@-del /f /q $(OUTDIR)\*.exe
+	@-del /f /q $(OUTDIR)\*.dll
+	@-del /f /q $(OUTDIR)\*.pdb
+	@-del /f /q $(OUTDIR)\*.ilk
+	@-del /f /q $(OUTDIR)\*.exp
+	@-del /f /q $(OUTDIR)\*.lib
+	@-del /f /q $(OUTDIR)\libxmlxx-tests\*.obj
+	@-del /f /q $(OUTDIR)\libxmlxx-tests\*.pdb
+	@-del /f /q $(OUTDIR)\libxmlxx-examples\*.obj
+	@-del /f /q $(OUTDIR)\libxmlxx-examples\*.pdb
+	@-del /f /q $(OUTDIR)\libxmlxx\*.res
+	@-del /f /q $(OUTDIR)\libxmlxx\*.obj
+	@-del /f /q $(OUTDIR)\libxmlxx\*.pdb
+	@-rd $(OUTDIR)\libxmlxx-tests
+	@-rd $(OUTDIR)\libxmlxx-examples
+	@-rd $(OUTDIR)\libxmlxx

--- a/MSVC_NMake/config-msvc.mak
+++ b/MSVC_NMake/config-msvc.mak
@@ -1,18 +1,19 @@
 # NMake Makefile portion for enabling features for Windows builds
 
-# These are the base minimum libraries required for building glibmm.
-!ifndef INCLUDEDIR
-INCLUDEDIR = $(PREFIX)\include
+# These are the base minimum libraries required for building libxml++.
+!ifndef BASE_INCLUDEDIR
+BASE_INCLUDEDIR = $(PREFIX)\include
 !endif
-!ifndef LIBDIR
-LIBDIR = $(PREFIX)\lib
+!ifndef BASE_LIBDIR
+BASE_LIBDIR = $(PREFIX)\lib
 !endif
-
-BASE_INCLUDES = /I$(INCLUDEDIR)
 
 # Please do not change anything beneath this line unless maintaining the NMake Makefiles
 LIBXMLXX_MAJOR_VERSION = 5
 LIBXMLXX_MINOR_VERSION = 0
+
+OUTDIR = vs$(VSVER)\$(CFG)\$(PLAT)
+DEPS_MKFILE = deps-vs$(VSVER)-$(PLAT)-$(CFG).mak
 
 !if "$(CFG)" == "debug" || "$(CFG)" == "Debug"
 DEBUG_SUFFIX = -d
@@ -20,17 +21,32 @@ DEBUG_SUFFIX = -d
 DEBUG_SUFFIX =
 !endif
 
-LIBXMLXX_BASE_CFLAGS =			\
-	/I.\libxml++ /I.. /EHsc	\
-	/wd4244 /wd4101	\
-	/std:c++17
+# Gather up dependencies for their include directories and lib/bin dirs.
+!if [for %t in (LIBXML2) do @(echo !ifndef %t_INCLUDEDIR>>$(DEPS_MKFILE) & echo %t_INCLUDEDIR=^$^(BASE_INCLUDEDIR^)>>$(DEPS_MKFILE) & echo !endif>>$(DEPS_MKFILE))]
+!endif
+!if [for %t in (LIBXML2) do @(echo !ifndef %t_LIBDIR>>$(DEPS_MKFILE) & echo %t_LIBDIR=^$^(BASE_LIBDIR^)>>$(DEPS_MKFILE) & echo !endif>>$(DEPS_MKFILE))]
+!endif
+
+!include $(DEPS_MKFILE)
+
+!if [del /f/q $(DEPS_MKFILE)]
+!endif
+
+DEPS_INCLUDES = /I$(LIBXML2_INCLUDEDIR)\libxml2 /I$(BASE_INCLUDEDIR)
+
+LIBXMLXX_BASE_CFLAGS =	\
+	/wd4244 /wd4101
 
 LIBXMLXX_EXTRA_INCLUDES =	\
 	/I$(INCLUDEDIR)\libxml2	\
 	/I$(INCLUDEDIR)
 
-LIBXMLXX_CFLAGS = /DLIBXMLPP_BUILD $(LIBXMLXX_BASE_CFLAGS) $(LIBXMLXX_EXTRA_INCLUDES)
-LIBXMLXX_EX_CFLAGS = $(LIBXMLXX_BASE_CFLAGS) $(LIBXMLXX_EXTRA_INCLUDES)
+LIBXMLXX_INCLUDES =	\
+	/I.\libxml++ /I..	\
+	$(DEPS_INCLUDES)
+
+LIBXMLXX_CFLAGS = /DLIBXMLPP_BUILD $(LIBXMLXX_BASE_CFLAGS)
+LIBXMLXX_EX_CFLAGS = $(LIBXMLXX_BASE_CFLAGS)
 
 # We build xml++-vc$(VSVER_LIB)-$(LIBXMLXX_MAJOR_VERSION)_$(LIBXMLXX_MINOR_VERSION).dll or
 #          xml++-vc$(VSVER_LIB)-d-$(LIBXMLXX_MAJOR_VERSION)_$(LIBXMLXX_MINOR_VERSION).dll at least
@@ -51,7 +67,12 @@ LIBXMLXX_LIBNAME = xml++-vc$(VSVER_LIB)$(DEBUG_SUFFIX)-$(LIBXMLXX_MAJOR_VERSION)
 LIBXMLXX_DLLNAME = $(LIBXMLXX_LIBNAME)
 !endif
 
-LIBXMLXX_DLL = vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBXMLXX_DLLNAME).dll
-LIBXMLXX_LIB = vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBXMLXX_LIBNAME).lib
+LIBXMLXX_DLL = $(OUTDIR)\$(LIBXMLXX_DLLNAME).dll
+LIBXMLXX_LIB = $(OUTDIR)\$(LIBXMLXX_LIBNAME).lib
 
 LIBXML2_LIBS = libxml2.lib
+
+DEP_LDFLAGS = /libpath:$(BASE_LIBDIR) $(LIBXML2_LIBS)
+!if "$(LIBXML2_LIBDIR)" != "$(BASE_LIBDIR)"
+DEP_LDFLAGS = /libpath:$(LIBXML2_LIBDIR) $(DEP_LDFLAGS)
+!endif

--- a/MSVC_NMake/config-msvc.mak
+++ b/MSVC_NMake/config-msvc.mak
@@ -14,6 +14,7 @@ LIBXMLXX_MINOR_VERSION = 0
 
 OUTDIR = vs$(VSVER)\$(CFG)\$(PLAT)
 DEPS_MKFILE = deps-vs$(VSVER)-$(PLAT)-$(CFG).mak
+BUILD_SNIPPET_MKFILE = libxmlxx-vs$(VSVER)-$(PLAT)-$(CFG).mak
 
 !if "$(CFG)" == "debug" || "$(CFG)" == "Debug"
 DEBUG_SUFFIX = -d

--- a/MSVC_NMake/create-lists-msvc.mak
+++ b/MSVC_NMake/create-lists-msvc.mak
@@ -38,10 +38,10 @@ NULL=
 !if [call create-lists.bat header libxmlxx.mak libxmlxx_OBJS]
 !endif
 
-!if [for %c in ($(cc_sources)) do @if "%~xc" == ".cc" @call create-lists.bat file libxmlxx.mak vs^$(VSVER)\^$(CFG)\^$(PLAT)\libxmlxx\%~nc.obj]
+!if [for %c in ($(cc_sources)) do @if "%~xc" == ".cc" @call create-lists.bat file libxmlxx.mak ^$^(OUTDIR^)\libxmlxx\%~nc.obj]
 !endif
 
-!if [@call create-lists.bat file libxmlxx.mak vs^$(VSVER)\^$(CFG)\^$(PLAT)\libxmlxx\libxml++.res]
+!if [@call create-lists.bat file libxmlxx.mak ^$^(OUTDIR^)\libxmlxx\libxml++.res]
 !endif
 
 !if [call create-lists.bat footer libxmlxx.mak]
@@ -56,19 +56,19 @@ NULL=
 !if [call create-lists.bat footer libxmlxx.mak]
 !endif
 
-!if [for %d in (examples tests) do @call create-lists.bat header libxmlxx.mak libxmlxx_%d & @(for /f %t in ('dir /ad /b ..\%d') do @call create-lists.bat file libxmlxx.mak vs$(VSVER)\$(CFG)\$(PLAT)\%t.exe) & @call create-lists.bat footer libxmlxx.mak]
+!if [for %d in (examples tests) do @call create-lists.bat header libxmlxx.mak libxmlxx_%d & @(for /f %t in ('dir /ad /b ..\%d') do @call create-lists.bat file libxmlxx.mak $(OUTDIR)\%t.exe) & @call create-lists.bat footer libxmlxx.mak]
 !endif
 
-!if [for %d in (examples tests) do @for /f %t in ('dir /ad /b ..\%d') do @call create-lists.bat header libxmlxx.mak %t_OBJS & @(for %s in (..\%d\%t\*.cc) do @call create-lists.bat file libxmlxx.mak vs$(VSVER)\$(CFG)\$(PLAT)\libxmlxx-%d\%t-%~ns.obj) & @call create-lists.bat footer libxmlxx.mak]
+!if [for %d in (examples tests) do @for /f %t in ('dir /ad /b ..\%d') do @call create-lists.bat header libxmlxx.mak %t_OBJS & @(for %s in (..\%d\%t\*.cc) do @call create-lists.bat file libxmlxx.mak $(OUTDIR)\libxmlxx-%d\%t-%~ns.obj) & @call create-lists.bat footer libxmlxx.mak]
 !endif
 
 !if [echo.>>libxmlxx.mak]
 !endif
 
-!if [for %d in (examples tests) do @for /f %t in ('dir /ad /b ..\%d') do @for %s in (..\%d\%t\*.cc) do @echo vs^$(VSVER)\^$(CFG)\^$(PLAT)\libxmlxx-%d\%t-%~ns.obj: %s>>libxmlxx.mak & @echo. if not exist ^$(@D)\ md ^$(@D)>>libxmlxx.mak & @echo.	^$(CXX) ^$(LIBXMLXX_EX_CFLAGS) ^$(CFLAGS) /Fo^$(@D)\%t-%~ns.obj /Fd^$(@D)\ ^$** /c>>libxmlxx.mak & @echo.>>libxmlxx.mak]
+!if [for %d in (examples tests) do @for /f %t in ('dir /ad /b ..\%d') do @for %s in (..\%d\%t\*.cc) do @echo ^$^(OUTDIR^)\libxmlxx-%d\%t-%~ns.obj: %s>>libxmlxx.mak & @echo. if not exist ^$(@D)\ md ^$(@D)>>libxmlxx.mak & @echo.	^$(CXX) ^$(CFLAGS) ^$(LIBXMLXX_EX_CFLAGS) ^$(LIBXMLXX_INCLUDES) /Fo^$(@D)\%t-%~ns.obj /Fd^$(@D)\ ^$** /c>>libxmlxx.mak & @echo.>>libxmlxx.mak]
 !endif
 
-!if [for %d in (examples tests) do @for /f %t in ('dir /ad /b ..\%d') do @echo vs^$(VSVER)\^$(CFG)\^$(PLAT)\%t.exe: ^$(LIBXMLXX_LIB) ^$(%t_OBJS)>>libxmlxx.mak & @echo.	link ^$(LDFLAGS) ^$** ^$(LIBXML2_LIBS) /out:^$@>>libxmlxx.mak & @echo.>>libxmlxx.mak]
+!if [for %d in (examples tests) do @for /f %t in ('dir /ad /b ..\%d') do @echo ^$^(OUTDIR^)\%t.exe: ^$(LIBXMLXX_LIB) ^$(%t_OBJS)>>libxmlxx.mak & @echo.	link ^$(LDFLAGS) ^$** ^$(DEP_LDFLAGS) /out:^$@>>libxmlxx.mak & @echo.>>libxmlxx.mak]
 !endif
 
 !if [echo.>>libxmlxx.mak]

--- a/MSVC_NMake/create-lists-msvc.mak
+++ b/MSVC_NMake/create-lists-msvc.mak
@@ -35,46 +35,46 @@ NULL=
 
 # For libxml++
 
-!if [call create-lists.bat header libxmlxx.mak libxmlxx_OBJS]
+!if [call create-lists.bat header $(BUILD_SNIPPET_MKFILE) libxmlxx_OBJS]
 !endif
 
-!if [for %c in ($(cc_sources)) do @if "%~xc" == ".cc" @call create-lists.bat file libxmlxx.mak ^$^(OUTDIR^)\libxmlxx\%~nc.obj]
+!if [for %c in ($(cc_sources)) do @if "%~xc" == ".cc" @call create-lists.bat file $(BUILD_SNIPPET_MKFILE) ^$^(OUTDIR^)\libxmlxx\%~nc.obj]
 !endif
 
-!if [@call create-lists.bat file libxmlxx.mak ^$^(OUTDIR^)\libxmlxx\libxml++.res]
+!if [@call create-lists.bat file $(BUILD_SNIPPET_MKFILE) ^$^(OUTDIR^)\libxmlxx\libxml++.res]
 !endif
 
-!if [call create-lists.bat footer libxmlxx.mak]
+!if [call create-lists.bat footer $(BUILD_SNIPPET_MKFILE)]
 !endif
 
-!if [call create-lists.bat header libxmlxx.mak libxmlxx_real_hdrs]
+!if [call create-lists.bat header $(BUILD_SNIPPET_MKFILE) libxmlxx_real_hdrs]
 !endif
 
-!if [for %c in ($(h_sources_public:/=\)) do @call create-lists.bat file libxmlxx.mak ..\libxml++\%c]
+!if [for %c in ($(h_sources_public:/=\)) do @call create-lists.bat file $(BUILD_SNIPPET_MKFILE) ..\libxml++\%c]
 !endif
 
-!if [call create-lists.bat footer libxmlxx.mak]
+!if [call create-lists.bat footer $(BUILD_SNIPPET_MKFILE)]
 !endif
 
-!if [for %d in (examples tests) do @call create-lists.bat header libxmlxx.mak libxmlxx_%d & @(for /f %t in ('dir /ad /b ..\%d') do @call create-lists.bat file libxmlxx.mak $(OUTDIR)\%t.exe) & @call create-lists.bat footer libxmlxx.mak]
+!if [for %d in (examples tests) do @call create-lists.bat header $(BUILD_SNIPPET_MKFILE) libxmlxx_%d & @(for /f %t in ('dir /ad /b ..\%d') do @call create-lists.bat file $(BUILD_SNIPPET_MKFILE) $(OUTDIR)\%t.exe) & @call create-lists.bat footer $(BUILD_SNIPPET_MKFILE)]
 !endif
 
-!if [for %d in (examples tests) do @for /f %t in ('dir /ad /b ..\%d') do @call create-lists.bat header libxmlxx.mak %t_OBJS & @(for %s in (..\%d\%t\*.cc) do @call create-lists.bat file libxmlxx.mak $(OUTDIR)\libxmlxx-%d\%t-%~ns.obj) & @call create-lists.bat footer libxmlxx.mak]
+!if [for %d in (examples tests) do @for /f %t in ('dir /ad /b ..\%d') do @call create-lists.bat header $(BUILD_SNIPPET_MKFILE) %t_OBJS & @(for %s in (..\%d\%t\*.cc) do @call create-lists.bat file $(BUILD_SNIPPET_MKFILE) $(OUTDIR)\libxmlxx-%d\%t-%~ns.obj) & @call create-lists.bat footer $(BUILD_SNIPPET_MKFILE)]
 !endif
 
-!if [echo.>>libxmlxx.mak]
+!if [echo.>>$(BUILD_SNIPPET_MKFILE)]
 !endif
 
-!if [for %d in (examples tests) do @for /f %t in ('dir /ad /b ..\%d') do @for %s in (..\%d\%t\*.cc) do @echo ^$^(OUTDIR^)\libxmlxx-%d\%t-%~ns.obj: %s>>libxmlxx.mak & @echo. if not exist ^$(@D)\ md ^$(@D)>>libxmlxx.mak & @echo.	^$(CXX) ^$(CFLAGS) ^$(LIBXMLXX_EX_CFLAGS) ^$(LIBXMLXX_INCLUDES) /Fo^$(@D)\%t-%~ns.obj /Fd^$(@D)\ ^$** /c>>libxmlxx.mak & @echo.>>libxmlxx.mak]
+!if [for %d in (examples tests) do @for /f %t in ('dir /ad /b ..\%d') do @for %s in (..\%d\%t\*.cc) do @echo ^$^(OUTDIR^)\libxmlxx-%d\%t-%~ns.obj: %s>>$(BUILD_SNIPPET_MKFILE) & @echo. if not exist ^$(@D)\ md ^$(@D)>>$(BUILD_SNIPPET_MKFILE) & @echo.	^$(CXX) ^$(CFLAGS) ^$(LIBXMLXX_EX_CFLAGS) ^$(LIBXMLXX_INCLUDES) /Fo^$(@D)\%t-%~ns.obj /Fd^$(@D)\ ^$** /c>>$(BUILD_SNIPPET_MKFILE) & @echo.>>$(BUILD_SNIPPET_MKFILE)]
 !endif
 
-!if [for %d in (examples tests) do @for /f %t in ('dir /ad /b ..\%d') do @echo ^$^(OUTDIR^)\%t.exe: ^$(LIBXMLXX_LIB) ^$(%t_OBJS)>>libxmlxx.mak & @echo.	link ^$(LDFLAGS) ^$** ^$(DEP_LDFLAGS) /out:^$@>>libxmlxx.mak & @echo.>>libxmlxx.mak]
+!if [for %d in (examples tests) do @for /f %t in ('dir /ad /b ..\%d') do @echo ^$^(OUTDIR^)\%t.exe: ^$(LIBXMLXX_LIB) ^$(%t_OBJS)>>$(BUILD_SNIPPET_MKFILE) & @echo.	link ^$(LDFLAGS) ^$** ^$(DEP_LDFLAGS) /out:^$@>>$(BUILD_SNIPPET_MKFILE) & @echo.>>$(BUILD_SNIPPET_MKFILE)]
 !endif
 
-!if [echo.>>libxmlxx.mak]
+!if [echo.>>$(BUILD_SNIPPET_MKFILE)]
 !endif
 
-!include libxmlxx.mak
+!include $(BUILD_SNIPPET_MKFILE)
 
-!if [del /f /q libxmlxx.mak]
+!if [del /f /q $(BUILD_SNIPPET_MKFILE)]
 !endif

--- a/MSVC_NMake/detectenv-msvc.mak
+++ b/MSVC_NMake/detectenv-msvc.mak
@@ -82,36 +82,24 @@ _HASH=^#
 !endif
 
 VSVER = 0
-PDBVER = 0
+PDBVER = 14
 VSVER_SUFFIX = 0
 
-!if $(VCVERSION) > 1499 && $(VCVERSION) < 1600
-PDBVER = 9
-!elseif $(VCVERSION) > 1599 && $(VCVERSION) < 1700
-PDBVER = 10
-!elseif $(VCVERSION) > 1699 && $(VCVERSION) < 1800
-PDBVER = 11
-!elseif $(VCVERSION) > 1799 && $(VCVERSION) < 1900
-PDBVER = 12
-!elseif $(VCVERSION) > 1899 && $(VCVERSION) < 2000
-PDBVER = 14
 !if $(VCVERSION) > 1909 && $(VCVERSION) < 1920
 VSVER_SUFFIX = 1
 VSVER = 15
 !elseif $(VCVERSION) > 1919 && $(VCVERSION) < 1930
 VSVER_SUFFIX = 2
 VSVER = 16
-!elseif $(VCVERSION) > 1929 && $(VCVERSION) < 2000
+!elseif $(VCVERSION) > 1929 && $(VCVERSION) < 1950
 VSVER_SUFFIX = 3
 VSVER = 17
-!else
-VSVER = $(PDBVER)
-!endif
-!else
-VSVER = $(PDBVER)
+!elseif $(VCVERSION) > 1949 && $(VCVERSION) < 2000
+VSVER_SUFFIX = 5
+VSVER = 18
 !endif
 
-!if $(VSVER) > 14 && "$(USE_COMPAT_LIBS)" != ""
+!if "$(USE_COMPAT_LIBS)" != ""
 VSVER_LIB = 150
 !else
 VSVER_LIB = $(PDBVER)$(VSVER_SUFFIX)
@@ -120,7 +108,7 @@ VSVER_LIB = $(PDBVER)$(VSVER_SUFFIX)
 !if "$(VSVER)" == "0"
 MSG = ^
 This NMake Makefile set supports Visual Studio^
-9 (2008) through 16 (2019).  Your Visual Studio^
+15 (2017) through 18 (2026).  Your Visual Studio^
 version is not supported.
 !error $(MSG)
 !endif

--- a/MSVC_NMake/detectenv-msvc.mak
+++ b/MSVC_NMake/detectenv-msvc.mak
@@ -120,20 +120,11 @@ VALID_CFGSET = TRUE
 
 # One may change these items, but be sure to test
 # the resulting binaries
+CFLAGS_ADD = /utf-8 /std:c++17 /EHsc
 !if "$(CFG)" == "release" || "$(CFG)" == "Release"
-CFLAGS_ADD_NO_GL = /MD /O2 /MP
-CFLAGS_ADD = $(CFLAGS_ADD_NO_GL) /GL
-!if "$(VSVER)" != "9"
-CFLAGS_ADD = $(CFLAGS_ADD) /d2Zi+
-CFLAGS_ADD_NO_GL = $(CFLAGS_ADD_NO_GL) /d2Zi+
-!if $(VSVER) >= 14
-CFLAGS_ADD = $(CFLAGS_ADD) /utf-8
-CFLAGS_ADD_NO_GL = $(CFLAGS_ADD_NO_GL) /utf-8
-!endif
-!endif
+CFLAGS_ADD = /MD /O2 /MP /GL $(CFLAGS_ADD)
 !else
-CFLAGS_ADD = /MDd /Od
-CFLAGS_ADD_NO_GL = $(CFLAGS_ADD)
+CFLAGS_ADD = /MDd /Od $(CFLAGS_ADD)
 !endif
 
 !if "$(PLAT)" == "x64"
@@ -145,20 +136,15 @@ LDFLAGS_ARCH = /machine:x86
 !endif
 
 !if "$(VALID_CFGSET)" == "TRUE"
-CFLAGS_NOGL = $(CFLAGS_ADD_NO_GL) /W3 /Zi
 CFLAGS = $(CFLAGS_ADD) /W3 /Zi
 
-LDFLAGS_BASE = $(LDFLAGS_ARCH) /libpath:$(LIBDIR) /DEBUG
+LDFLAGS_BASE = $(LDFLAGS_ARCH) /DEBUG
 
 !if "$(CFG)" == "debug" || "$(CFG)" == "Debug"
-ARFLAGS_NOLTCG = $(LDFLAGS_ARCH)
 ARFLAGS = $(LDFLAGS_ARCH)
-LDFLAGS_NOLTCG = $(LDFLAGS_BASE)
 LDFLAGS = $(LDFLAGS_BASE)
 !else
-ARFLAGS_NOLTCG = $(LDFLAGS_ARCH) /LTCG
-ARFLAGS = $(ARFLAGS_NOLTCG) /LTCG
-LDFLAGS_NOLTCG = $(LDFLAGS_BASE) /opt:ref
-LDFLAGS = $(LDFLAGS_NOLTCG) /LTCG
+ARFLAGS = $(LDFLAGS_ARCH) /LTCG
+LDFLAGS = $(LDFLAGS_BASE) /LTCG /opt:ref
 !endif
 !endif

--- a/MSVC_NMake/info-msvc.mak
+++ b/MSVC_NMake/info-msvc.mak
@@ -10,19 +10,14 @@ all-build-info:
 help:
 	@echo.
 	@echo ============================
-	@echo Building glibmm Using NMake
+	@echo Building libxml++ Using NMake
 	@echo ============================
-	@echo nmake /f Makefile.vc CFG=[release^|debug] ^<PREFIX=PATH^> ^<option1=xxx option2=xxx^>
+	@echo nmake /f Makefile.vc CFG=[release^|debug] ^<option1=xxx option2=xxx^>
 	@echo.
 	@echo Where:
 	@echo ------
 	@echo CFG: Required, use CFG=release for an optimized build and CFG=debug
 	@echo for a debug build.  PDB files are generated for all builds.
-	@echo.
-	@echo PREFIX: Optional, the path where dependent libraries and tools may be
-	@echo found, default is ^$(srcrootdir)\..\vs^$(short_vs_ver)\^$(platform),
-	@echo where ^$(short_vs_ver) is 15 for VS 2017 and so on; and
-	@echo ^$(platform) is Win32 for 32-bit builds and x64 for x64 builds.
 	@echo.
 	@echo -----
 	@echo A few options are supported here, namely:
@@ -37,20 +32,28 @@ help:
 	@echo libxml++config.h and libxml++.rc if not already present in .\libxml++.
 	@echo.
 	@echo PREFIX: Base directory to look for dependencies and location for where the
-	@echo build results are copied, default is in ..\..\^$(short_vs_ver)\^$(platform)
+	@echo build results are copied, default is in ..\..\$$(short_vs_ver)\\$$(platform)
 	@echo.
-	@echo INCLUDEDIR: Base include directory to look for dependenct headers,
-	@echo such as libxml2, default is in ^$(PREFIX)\include.
+	@echo BASE_INCLUDEDIR: Base include directory to look for dependenct headers,
+	@echo such as libxml2, default is in $$(PREFIX)\\include.
 	@echo.
-	@echo LIBDIR: Base directory to look for dependent libraries, such as libxml2,
-	@echo default is in ^$(PREFIX)\lib.
+	@echo BASE_LIBDIR: Base directory to look for dependent libraries, such as libxml2,
+	@echo default is in $$(PREFIX)\\lib, and libxml2's dependent libraries if libxml2
+	@echo is a static build.
+	@echo.
+	@echo [DEP]_INCLUDEDIR: Directory to look for headers for [DEP], default is in
+	@echo $$(BASE_INCLUDEDIR)\\include. [DEP] includes LIBXML2; the 'libxml2'
+	@echo subdirectory of $$(LIBXML2_INCLUDEDIR) will be looked for automatically
+	@echo.
+	@echo [DEP]_INCLUDEDIR: Directory to look for .lib's for [DEP], default is in
+	@echo $$(BASE_INCLUDEDIR)\\lib. [DEP] includes LIBXML2.
 	@echo.
 	@echo ======
 	@echo A 'clean' target is supported to remove all generated files, intermediate
 	@echo object files and binaries for the specified configuration.
 	@echo.
 	@echo An 'install' target is supported to copy the build (DLLs, utility programs,
-	@echo LIBs, along with the header files) to appropriate locations under ^$(PREFIX).
+	@echo LIBs, along with the header files) to appropriate locations under $$(PREFIX).
 	@echo.
 	@echo A 'tests' target is supported to build the test programs.
 	@echo ======

--- a/meson.build
+++ b/meson.build
@@ -188,7 +188,9 @@ msvc14x_toolset_ver = ''
 
 if is_msvc
   if use_msvc14x_toolset_ver
-    if cpp_compiler.version().version_compare('>=19.30')
+    if cpp_compiler.version().version_compare('>=19.50')
+      msvc14x_toolset_ver = '-vc145'
+    elif cpp_compiler.version().version_compare('>=19.30')
       msvc14x_toolset_ver = '-vc143'
     elif cpp_compiler.version().version_compare('>=19.20')
       msvc14x_toolset_ver = '-vc142'


### PR DESCRIPTION
Hi,

This attempts to update the Visual Studio build files by:

* Making the Meson and NMake Makefiles distinguish VS2026 builds from VS2022 builds.
* Clean up the NMake Makefiles a bit by consolidating repetitive items, and standardize on using the `/GL`  compiler flag and the corresponding `/LTCG` linker flag, as no gendef is being used here.
* Make the NMake Makefiles more flexible in locating headers and .lib's for dependencies (i.e. libxml2).
* Make the NMake Makefiles more robust when attempting to overlap builds with different toolsets and configs.
* Update the build documentation to reflect the changes here.

With blessings, thank you!